### PR TITLE
Enhance Hamiltonian calculations and refactor QubitBase methods

### DIFF
--- a/HybridSuperQubits/ferbo.py
+++ b/HybridSuperQubits/ferbo.py
@@ -203,6 +203,21 @@ class Ferbo(QubitBase):
             phase_op = self.phase_operator()[:self.dimension//2,:self.dimension//2] - self.phase * np.eye(self.dimension // 2)
             return - self.Gamma/2 * np.kron(sigma_z(), sinm(phase_op/2)) + self.delta_Gamma/2 * np.kron(sigma_y(), cosm(phase_op/2))
         
+    def d2_hamiltonian_d_phase2(self) -> np.ndarray:
+        """
+        Returns the second derivative of the Hamiltonian with respect to the external magnetic phase.
+
+        Returns
+        -------
+        np.ndarray
+            The second derivative of the Hamiltonian with respect to the external magnetic phase.
+        """
+        if self.flux_grouping == 'L':
+            return self.El * np.eye(self.dimension)
+        elif self.flux_grouping == 'ABS':
+            phase_op = self.phase_operator()[:self.dimension//2,:self.dimension//2] - self.phase * np.eye(self.dimension // 2)
+            return self.Gamma/4 * np.kron(sigma_z(), cosm(phase_op/2)) + self.delta_Gamma/4 * np.kron(sigma_y(), sinm(phase_op/2))
+        
                 
     def d_hamiltonian_d_er(self) -> np.ndarray:
         """

--- a/HybridSuperQubits/ferbo.py
+++ b/HybridSuperQubits/ferbo.py
@@ -188,6 +188,18 @@ class Ferbo(QubitBase):
         """
         return 8 * self.Ec * (self.n_operator() - self.delta_Gamma/4/(self.Gamma+self.Delta) * np.kron(sigma_z(), np.eye(self.dimension//2)))
     
+    def d2_hamiltonian_d_ng2(self) -> np.ndarray:
+        """
+        Returns the second derivative of the Hamiltonian with respect to the number of charge offset.
+        
+        Returns
+        -------
+        np.ndarray
+            The second derivative of the Hamiltonian with respect to the number of charge offset.
+        
+        """
+        return 8 * self.Ec * np.eye(self.dimension)
+    
     def d_hamiltonian_d_phase(self) -> np.ndarray:
         """
         Returns the derivative of the Hamiltonian with respect to the external magnetic phase.

--- a/HybridSuperQubits/qubit_base.py
+++ b/HybridSuperQubits/qubit_base.py
@@ -1004,6 +1004,10 @@ class QubitBase(ABC):
             noise_operator = [noise_operator]
         
         missing_operators = [op for op in noise_operator if spectrum_data is None or op not in spectrum_data.matrixelem_table]
+        if not missing_operators:
+            if spectrum_data.matrixelem_table[noise_operator[0]].shape[1] != spectrum_data.matrixelem_table[noise_operator[0]].shape[2]:
+                missing_operators = [noise_operator[0]]
+                
         if missing_operators:
             new_spec = self.get_matelements_vs_paramvals(noise_operator, param_name, param_vals, evals_count=evals_count)
             spectrum_data.matrixelem_table[noise_operator] = new_spec.matrixelem_table[noise_operator]

--- a/HybridSuperQubits/qubit_base.py
+++ b/HybridSuperQubits/qubit_base.py
@@ -1127,7 +1127,7 @@ class QubitBase(ABC):
             param_vals=param_vals, 
             A_noise=A_noise, 
             noise_channel='charge_noise', 
-            noise_operator='d_hamiltonian_d_ng', 
+            noise_operators=['d_hamiltonian_d_ng', 'd2_hamiltonian_d_ng2'], 
             evals_count=evals_count, 
             spectrum_data=spectrum_data, 
             **kwargs
@@ -1519,6 +1519,7 @@ class QubitBase(ABC):
                     operators.add('d2_hamiltonian_d_phase2')
                 elif channel == 'charge_noise':
                     operators.add('d_hamiltonian_d_ng')
+                    operators.add('d2_hamiltonian_d_ng2')
                 else:
                     raise ValueError(f"Unsupported Tphi noise channel: {channel}")
             spectrum_data = self.get_matelements_vs_paramvals(list(operators), param_name, param_vals)

--- a/HybridSuperQubits/qubit_base.py
+++ b/HybridSuperQubits/qubit_base.py
@@ -65,20 +65,23 @@ class QubitBase(ABC):
         """
         pass
     
-    def eigensys(self, evals_count: int = 6) -> Tuple[np.ndarray, np.ndarray]:
+    def eigensys(self, evals_count: int = None) -> Tuple[np.ndarray, np.ndarray]:
         """
         Calculates eigenvalues and corresponding eigenvectors using scipy.linalg.eigh.
 
         Parameters
         ----------
         evals_count : int, optional
-            Number of desired eigenvalues/eigenstates (default is 6).
+            Number of desired eigenvalues/eigenstates (default is None, in which case all are calculated).
 
         Returns
         -------
         Tuple[np.ndarray, np.ndarray]
             Eigenvalues and eigenvectors as numpy arrays.
         """
+        if evals_count is None:
+            evals_count = self.dimension
+            
         hamiltonian_mat = self.hamiltonian()
         evals, evecs = eigh(
             hamiltonian_mat,
@@ -88,20 +91,23 @@ class QubitBase(ABC):
         )
         return evals, evecs
     
-    def eigenvals(self, evals_count: int = 6) -> np.ndarray:
+    def eigenvals(self, evals_count: int = None) -> np.ndarray:
         """
         Calculates eigenvalues using scipy.linalg.eigh.
 
         Parameters
         ----------
         evals_count : int, optional
-            Number of desired eigenvalues (default is 6).
+            Number of desired eigenvalues (default is None, in which case all are calculated).
 
         Returns
         -------
         np.ndarray
             Eigenvalues as a numpy array.
         """
+        if evals_count is None:
+            evals_count = self.dimension
+            
         hamiltonian_mat = self.hamiltonian()
         evals = eigh(
             hamiltonian_mat,
@@ -111,7 +117,7 @@ class QubitBase(ABC):
         )
         return np.sort(evals)
     
-    def get_spectrum_vs_paramvals(self, param_name: str, param_vals: List[float], evals_count: int = 6, subtract_ground: bool = False)  -> SpectrumData:
+    def get_spectrum_vs_paramvals(self, param_name: str, param_vals: List[float], evals_count: int = None, subtract_ground: bool = False)  -> SpectrumData:
         """
         Calculates the eigenenergies and eigenstates for a range of parameter values.
 
@@ -122,7 +128,7 @@ class QubitBase(ABC):
         param_vals : List[float]
             The values of the parameter to vary.
         evals_count : int, optional
-            The number of eigenvalues and eigenstates to calculate (default is 6).
+            The number of eigenvalues and eigenstates to calculate (default is None, in which case all are calculated).
         subtract_ground : bool, optional
             Whether to subtract the ground state energy from the eigenenergies (default is False).
 
@@ -131,6 +137,9 @@ class QubitBase(ABC):
         Tuple[np.ndarray, np.ndarray]
             The eigenenergies and eigenstates for the range of parameter values.
         """
+        if evals_count is None:
+            evals_count = self.dimension
+            
         eigenenergies_array = []
         eigenstates_array = []
         
@@ -157,7 +166,7 @@ class QubitBase(ABC):
         
         return spectrum_data  
         
-    def matrixelement_table(self, operator: str, evecs: np.ndarray = None, evals_count: int = 6) -> np.ndarray:
+    def matrixelement_table(self, operator: str, evecs: np.ndarray = None, evals_count: int = None) -> np.ndarray:
         """
         Returns a table of matrix elements for a given operator with respect to the eigenstates.
 
@@ -168,13 +177,15 @@ class QubitBase(ABC):
         evecs : np.ndarray, optional
             The eigenstates (default is None, in which case they are calculated).
         evals_count : int, optional
-            The number of eigenvalues and eigenstates to calculate (default is 6).
+            The number of eigenvalues and eigenstates to calculate (default is None, in which case all are calculated).
 
         Returns
         -------
         np.ndarray
             The table of matrix elements.
         """
+        if evals_count is None:
+            evals_count = self.dimension
         
         if evecs is None:
             _, evecs = self.eigensys(evals_count)
@@ -189,7 +200,7 @@ class QubitBase(ABC):
         operators: Union[str, List[str]], 
         param_name: str, 
         param_vals: np.ndarray, 
-        evals_count: int = 6
+        evals_count: int = None
         ) -> SpectrumData:
         #TODO: #9 Add spectrum_data as optional parameter in case it was already computed the esys.
         """
@@ -204,13 +215,16 @@ class QubitBase(ABC):
         param_vals : np.ndarray
             The values of the parameter to vary.
         evals_count : int, optional
-            The number of eigenvalues and eigenstates to calculate (default is 6).
+            The number of eigenvalues and eigenstates to calculate (default is None, in which case all are calculated).
 
         Returns
         -------
         Dict[str, Dict[str, np.ndarray]]
             The matrix elements for the operators over the range of parameter values.
         """
+        if evals_count is None:
+            evals_count = self.dimension
+            
         if isinstance(operators, str):
             operators = [operators]
                         
@@ -464,7 +478,7 @@ class QubitBase(ABC):
         noise_channels: Union[str, List[str]],
         param_name: str = None, 
         param_vals: np.ndarray = None, 
-        evals_count: int = 6,
+        evals_count: int = None,
         spectrum_data: SpectrumData = None,
         **kwargs
         ) -> SpectrumData:
@@ -480,7 +494,7 @@ class QubitBase(ABC):
         param_vals : np.ndarray
             The values of the parameter to vary.
         evals_count : int, optional
-            The number of eigenvalues and eigenstates to calculate (default is 6).
+            The number of eigenvalues and eigenstates to calculate (default is None, in which case all are calculated).
         spectrum_data : SpectrumData, optional
             Precomputed spectral data to use (default is None).
         **kwargs
@@ -491,6 +505,9 @@ class QubitBase(ABC):
         SpectrumData
             The T1 times for the specified noise channels over the range of parameter values.
         """
+        if evals_count is None:
+            evals_count = self.dimension
+            
         if isinstance(noise_channels, str):
             noise_channels = [noise_channels]
             
@@ -522,7 +539,7 @@ class QubitBase(ABC):
         self, 
         param_name: str = None, 
         param_vals: np.ndarray = None, 
-        evals_count: int = 6, 
+        evals_count: int = None,
         spectrum_data: SpectrumData = None,
         Q_cap: Union[float, Callable] = None,
         T: float = 0.015, 
@@ -538,7 +555,7 @@ class QubitBase(ABC):
         param_vals : np.ndarray, optional
             The values of the parameter to vary.
         evals_count : int, optional
-            The number of eigenvalues and eigenstates to calculate (default is 6).
+            The number of eigenvalues and eigenstates to calculate (default is None, in which case all are calculated).
         spectrum_data : SpectrumData, optional
             Precomputed spectral data to use (default is None).
         Q_cap : Union[float, Callable], optional
@@ -553,6 +570,9 @@ class QubitBase(ABC):
         SpectrumData
             The T1 times for capacitive noise over the range of parameter values.
         """
+        if evals_count is None:
+            evals_count = self.dimension
+            
         if Q_cap is None:
             Q_cap_fun = lambda omega: 1e6 * (2 * np.pi * 6e9 / np.abs(omega))**0.7 # Assuming that Ec is in GHz
         elif callable(Q_cap):
@@ -575,7 +595,7 @@ class QubitBase(ABC):
         self, 
         param_name: str = None, 
         param_vals: np.ndarray = None, 
-        evals_count: int = 6, 
+        evals_count: int = None, 
         spectrum_data: SpectrumData = None,
         Q_ind: float = None,
         T: float = 0.015, 
@@ -591,7 +611,7 @@ class QubitBase(ABC):
         param_vals : np.ndarray, optional
             The values of the parameter to vary.
         evals_count : int, optional
-            The number of eigenvalues and eigenstates to calculate (default is 6).
+            The number of eigenvalues and eigenstates to calculate (default is None, in which case all are calculated).
         spectrum_data : SpectrumData, optional
             Precomputed spectral data to use (default is None).
         Q_ind : float, optional
@@ -606,6 +626,9 @@ class QubitBase(ABC):
         SpectrumData
             The T1 times for inductive noise over the range of parameter values.
         """
+        if evals_count is None:
+            evals_count = self.dimension
+            
         if Q_ind is None:
             Q_ind_fun = lambda omega: 500e6 * (
                 k0(h * 0.5e9 / (2 * k * T)) * np.sinh(h * 0.5e9 / (2 * k * T))
@@ -632,7 +655,7 @@ class QubitBase(ABC):
         self,
         param_name: str = None,
         param_vals: np.ndarray = None,
-        evals_count: int = 6,
+        evals_count: int = None,
         spectrum_data: SpectrumData = None,
         Z: float = 50,
         T: float = 0.015,
@@ -648,7 +671,7 @@ class QubitBase(ABC):
         param_vals : np.ndarray, optional
             The values of the parameter
         evals_count : int, optional
-            The number of eigenvalues and eigenstates to calculate (default is 6).
+            The number of eigenvalues and eigenstates to calculate (default is None, in which case all are calculated).
         spectrum_data : SpectrumData, optional
             Precomputed spectral data to use (default is None).
         Z : float, optional
@@ -662,6 +685,9 @@ class QubitBase(ABC):
         SpectrumData
             The T1 times for charge impedance noise over the range of parameter values.
         """
+        if evals_count is None:
+            evals_count = self.dimension
+            
         def spectral_density(omega, T):
             Rk = h / ((2 * e)**2)
             return omega/1e9 / Rk * Z * (1 + 1/np.tanh(hbar * np.abs(omega) / (2 * k * T)))
@@ -677,7 +703,7 @@ class QubitBase(ABC):
         self,
         param_name: str = None,
         param_vals: np.ndarray = None,
-        evals_count: int = 6,
+        evals_count: int = None,
         spectrum_data: SpectrumData = None,
         M: float = 2500,
         Z: float = 50,
@@ -694,7 +720,7 @@ class QubitBase(ABC):
         param_vals : np.ndarray, optional
             The values of the parameter
         evals_count : int, optional
-            The number of eigenvalues and eigenstates to calculate (default is 6).
+            The number of eigenvalues and eigenstates to calculate (default is None, in which case all are calculated).
         spectrum_data : SpectrumData, optional
             Precomputed spectral data to use (default is None).
         M : float, optional
@@ -711,7 +737,9 @@ class QubitBase(ABC):
         SpectrumData
             The T1 times for flux bias line noise over the range of parameter values.
         """
-        
+        if evals_count is None:
+            evals_count = self.dimension
+            
         def spectral_density(omega, T):
             return 4 * np.pi**2 * M**2 * np.abs(omega) * 1e9 * h / Z * (1 + 1/np.tanh(hbar * np.abs(omega) / (2 * k * T)))
         
@@ -726,7 +754,7 @@ class QubitBase(ABC):
         self,
         param_name: str = None,
         param_vals: np.ndarray = None,
-        evals_count: int = 6,
+        evals_count: int = None,
         spectrum_data: SpectrumData = None,
         A_noise: float = 1e-6,
         **kwargs
@@ -741,7 +769,7 @@ class QubitBase(ABC):
         param_vals : np.ndarray, optional
             The values of the parameter
         evals_count : int, optional
-            The number of eigenvalues and eigenstates to calculate (default is 6).
+            The number of eigenvalues and eigenstates to calculate (default is None, in which case all are calculated).
         spectrum_data : SpectrumData, optional
             Precomputed spectral data to use (default is None).
         A_noise : float, optional
@@ -754,6 +782,9 @@ class QubitBase(ABC):
         SpectrumData
             The T1 times for 1/f flux noise over the range of parameter values.
         """
+        if evals_count is None:
+            evals_count = self.dimension
+            
         def spectral_density(omega, T):
             return 2 * np.pi * A_noise**2 / np.abs(omega)
         
@@ -769,7 +800,7 @@ class QubitBase(ABC):
         self,
         param_name: str = None,
         param_vals: np.ndarray = None,
-        evals_count: int = 6,
+        evals_count: int = None,
         spectrum_data: SpectrumData = None,
         A_noise: float = 1e-7,
         N: int = 100,
@@ -785,7 +816,7 @@ class QubitBase(ABC):
         param_vals : np.ndarray, optional
             The values of the parameter to vary.
         evals_count : int, optional
-            The number of eigenvalues and eigenstates to calculate (default is 6).
+            The number of eigenvalues and eigenstates to calculate (default is None, in which case all are calculated).
         spectrum_data : SpectrumData, optional
             Precomputed spectral data to use (default is None).
         A_noise : float, optional
@@ -798,6 +829,8 @@ class QubitBase(ABC):
         SpectrumData
             The T1 times for critical current noise over the range of parameter values.
         """
+        if evals_count is None:
+            evals_count = self.dimension
         
         def spectral_density(omega, T):
             return 2 * np.pi * (A_noise * self.El / np.sqrt(N))**2 / omega * 1e9
@@ -814,7 +847,7 @@ class QubitBase(ABC):
         self,
         param_name: str = None,
         param_vals: np.ndarray = None,
-        evals_count: int = 6,
+        evals_count: int = None,
         spectrum_data: SpectrumData = None,
         A_noise: float = 0.04,
         **kwargs
@@ -841,6 +874,8 @@ class QubitBase(ABC):
         SpectrumData
             The T1 times for Fermi level noise over the range of parameter values.
         """
+        if evals_count is None:
+            evals_count = self.dimension
         
         def spectral_density(omega, T):
             return 2 * np.pi * 1e9 * A_noise**2 *np.abs(1/(omega*1e-9) + 0.01 * omega*1e-9 * 1/np.tanh(hbar * omega / (2 * k * T)))
@@ -927,7 +962,7 @@ class QubitBase(ABC):
         A_noise: float,
         noise_channel: str,
         noise_operator: Union[str, List[str]],
-        evals_count: int = 6,
+        evals_count: int = None,
         spectrum_data: SpectrumData = None,
         **kwargs
         ) -> SpectrumData:
@@ -959,6 +994,9 @@ class QubitBase(ABC):
         SpectrumData
             The Tphi times for the specified noise channels over the range of parameter values.
         """
+        if evals_count is None:
+            evals_count = self.dimension
+            
         p = {"omega_ir": 2 * np.pi * 1, "omega_uv": 3 * 2 * np.pi * 1e6, "t_exp": 10e-6}
         p.update(kwargs)
         
@@ -1010,7 +1048,7 @@ class QubitBase(ABC):
         param_name: str, 
         param_vals: np.ndarray, 
         A_noise: float = 1e-6,
-        evals_count: int = 6,
+        evals_count: int = None,
         spectrum_data: SpectrumData = None,
         **kwargs
         ) -> SpectrumData:
@@ -1053,7 +1091,7 @@ class QubitBase(ABC):
         param_name: str = None,
         param_vals: np.ndarray = None,
         A_noise: float = 1e-4,
-        evals_count: int = 6,
+        evals_count: int = None,
         spectrum_data: SpectrumData = None,
         **kwargs
     ) -> SpectrumData:
@@ -1165,11 +1203,11 @@ class QubitBase(ABC):
         noise_channels: Union[str, List[str]],
         param_name: str = None, 
         param_vals: np.ndarray = None, 
-        evals_count: int = 6,
+        evals_count: int = None,
         spectrum_data: SpectrumData = None,
         **kwargs
         ) -> SpectrumData:
-        
+            
         if spectrum_data is not None:
             param_name = spectrum_data.param_name
             param_vals = spectrum_data.param_vals
@@ -1470,7 +1508,6 @@ class QubitBase(ABC):
             noise_channels = [noise_channels]
             
         if spectrum_data is None:
-            evals_count = max(max(i,j) for i, j in select_elems) + 1
             operators = set()
             for channel in noise_channels:
                 if channel == 'flux_noise':
@@ -1480,7 +1517,7 @@ class QubitBase(ABC):
                     operators.add('d_hamiltonian_d_ng')
                 else:
                     raise ValueError(f"Unsupported Tphi noise channel: {channel}")
-            spectrum_data = self.get_matelements_vs_paramvals(list(operators), param_name, param_vals, evals_count=50)
+            spectrum_data = self.get_matelements_vs_paramvals(list(operators), param_name, param_vals)
         else:
             param_name = spectrum_data.param_name
             param_vals = spectrum_data.param_vals

--- a/HybridSuperQubits/qubit_base.py
+++ b/HybridSuperQubits/qubit_base.py
@@ -913,7 +913,7 @@ class QubitBase(ABC):
         spectrum_data.t1_table[noise_channel] = t1_table        
         return spectrum_data
     
-    def _get_tphi_vs_paramvals(
+    def _get_tphi_1_over_f_vs_paramvals(
         self, 
         param_name: str, 
         param_vals: np.ndarray, 
@@ -1016,7 +1016,7 @@ class QubitBase(ABC):
         SpectrumData
             The Tphi times for flux noise over the range of parameter values.
         """
-        return self._get_tphi_vs_paramvals(
+        return self._get_tphi_1_over_f_vs_paramvals(
             param_name=param_name, 
             param_vals=param_vals, 
             A_noise=A_noise, 
@@ -1059,7 +1059,7 @@ class QubitBase(ABC):
         SpectrumData
             The Tphi times for charge noise over the range of parameter values.
         """
-        return self._get_tphi_vs_paramvals(
+        return self._get_tphi_1_over_f_vs_paramvals(
             param_name=param_name, 
             param_vals=param_vals, 
             A_noise=A_noise, 


### PR DESCRIPTION
- Getting the second derivative of the energy from matrix elements in `_get_tphi_1_over_f_vs_paramvals`.
- Change the name of `_get_tphi_vs_paramvals` to `_get_tphi_1_over_f_vs_paramvals`.
- Add methods `d2_hamiltonian_d_ng2`and `d2_hamiltonian_d_phase2`in `Ferbo` class.
- Replace the default value of `evals_count` from 6 to the total.