### PR TITLE
Feature/split relaxation absortion processes

### DIFF
--- a/HybridSuperQubits/andreev.py
+++ b/HybridSuperQubits/andreev.py
@@ -228,37 +228,6 @@ class Andreev(QubitBase):
             Wave function data containing basis labels, amplitudes, and energy.
         """
         return NotImplementedError("Not implemented yet")
-        # if esys is None:
-        #     evals_count = max(which + 1, 3)
-        #     evals, evecs = self.eigensys(evals_count)
-        # else:
-        #     evals, evecs = esys
-            
-        # dim = self.dimension//2
-        
-        # if basis == 'default':
-        #     evecs = evecs.T
-        # elif basis == 'abs':
-        #     U = (1 / np.sqrt(2)) * np.array([[1, 1], [1, -1]])
-        #     change_of_basis_operator = np.kron(np.eye(dim), U)
-        #     evecs = (change_of_basis_operator @ evecs).T        
-                        
-        # if phi_grid is None:
-        #     phi_grid = np.linspace(-5 * np.pi, 5 * np.pi, 151)
-
-        # phi_basis_labels = phi_grid
-        # wavefunc_osc_basis_amplitudes = evecs[which, :]
-        # phi_wavefunc_amplitudes = np.zeros((2, len(phi_grid)), dtype=np.complex_)
-        # phi_osc = self.phi_osc()
-        # for n in range(dim):
-        #     phi_wavefunc_amplitudes[0] += wavefunc_osc_basis_amplitudes[2 * n] * self.harm_osc_wavefunction(n, phi_basis_labels, phi_osc)
-        #     phi_wavefunc_amplitudes[1] += wavefunc_osc_basis_amplitudes[2 * n + 1] * self.harm_osc_wavefunction(n, phi_basis_labels, phi_osc)
-
-        # return {
-        #     "basis_labels": phi_basis_labels,
-        #     "amplitudes": phi_wavefunc_amplitudes,
-        #     "energy": evals[which]
-        # }
         
     def potential(self, phi: Union[float, np.ndarray]) -> np.ndarray:
         """
@@ -275,86 +244,7 @@ class Andreev(QubitBase):
             The potential energy values.
         """
         return NotImplementedError("Not implemented yet")
-        # phi_array = np.atleast_1d(phi)
-        # evals_array = np.zeros((len(phi_array), 2))
-        # phi_ext = 2 * np.pi * self.phase
 
-        # for i, phi_val in enumerate(phi_array):
-        #     if self.flux_grouping == 'ABS':
-        #         inductive_term = 0.5 * self.El * phi_val**2 * np.eye(2)
-        #         andreev_term = -self.Gamma * np.cos((phi_val + self.phase) / 2) * sigma_x() - self.delta_Gamma * np.sin((phi_val + self.phase) / 2) * sigma_y() - self.er * sigma_z()
-        #     elif self.flux_grouping == 'L':
-        #         inductive_term = 0.5 * self.El * (phi_val + phi_ext)**2 * np.eye(2)
-        #         andreev_term = -self.Gamma * np.cos(phi_val / 2) * sigma_x() - self.delta_Gamma * np.sin(phi_val / 2) * sigma_y() - self.er * sigma_z()
-            
-        #     potential_operator = inductive_term + andreev_term
-        #     evals_array[i] = eigh(
-        #         potential_operator,
-        #         eigvals_only=True,
-        #         check_finite=False,
-        # )
-
-        # return evals_array
-    
-    def tphi_1_over_f(
-        self, 
-        A_noise: float, 
-        i: int, 
-        j: int, 
-        noise_op: str,
-        esys: Tuple[np.ndarray, np.ndarray] = None,
-        get_rate: bool = False,
-        **kwargs
-        ) -> float:
-        """
-        Calculates the 1/f dephasing time (or rate) due to an arbitrary noise source.
-
-        Parameters
-        ----------
-        A_noise : float
-            Noise strength.
-        i : int
-            State index that along with j defines a qubit.
-        j : int
-            State index that along with i defines a qubit.
-        noise_op : str
-            Name of the noise operator, typically Hamiltonian derivative w.r.t. noisy parameter.
-        esys : Tuple[np.ndarray, np.ndarray], optional
-            Precomputed eigenvalues and eigenvectors (default is None).
-        get_rate : bool, optional
-            Whether to return the rate instead of the Tphi time (default is False).
-
-        Returns
-        -------
-        float
-            The 1/f dephasing time (or rate).
-        """
-        p = {"omega_ir": 2 * np.pi * 1, "omega_uv": 3 * 2 * np.pi * 1e6, "t_exp": 10e-6}
-        p.update(kwargs)
-                
-        if esys is None:
-            evals, evecs = self.eigensys(evals_count=max(j, i) + 1)
-        else:
-            evals, evecs = esys
-
-        noise_operator = getattr(self, noise_op)()    
-        dEij_d_lambda = np.abs(evecs[i].conj().T @ noise_operator @ evecs[i] - evecs[j].conj().T @ noise_operator @ evecs[j])
-
-        rate = (dEij_d_lambda * A_noise * np.sqrt(2 * np.abs(np.log(p["omega_ir"] * p["t_exp"]))))
-        rate *= 2 * np.pi * 1e9 # Convert to rad/s
-
-        return rate if get_rate else 1 / rate
-    
-    def tphi_1_over_f_flux(
-        self, 
-        A_noise: float = 1e-6,
-        i: int = 0, 
-        j: int = 1, 
-        esys: Tuple[np.ndarray, np.ndarray] = None, 
-        get_rate: bool = False, 
-        **kwargs
-        ) -> float:
-        return self.tphi_1_over_f(A_noise, i, j, 'd_hamiltonian_d_phase', esys=esys, get_rate=get_rate, **kwargs)
 
     def plot_wavefunction(
         self, 

--- a/HybridSuperQubits/ferbo.py
+++ b/HybridSuperQubits/ferbo.py
@@ -186,7 +186,8 @@ class Ferbo(QubitBase):
             The derivative of the Hamiltonian with respect to the number of charge offset.
         
         """
-        return 8 * self.Ec * (self.n_operator() - self.delta_Gamma/4/(self.Gamma+self.Delta) * np.kron(sigma_z(), np.eye(self.dimension//2)))
+        n_x = self.delta_Gamma/4/(self.Gamma+self.Delta)
+        return - 8 * self.Ec * (self.n_operator() + n_x * np.kron(sigma_x(), np.eye(self.dimension//2)))
     
     def d2_hamiltonian_d_ng2(self) -> np.ndarray:
         """

--- a/HybridSuperQubits/ferbo.py
+++ b/HybridSuperQubits/ferbo.py
@@ -360,55 +360,6 @@ class Ferbo(QubitBase):
 
         return evals_array
     
-    def tphi_1_over_f(
-        self, 
-        A_noise: float, 
-        i: int, 
-        j: int, 
-        noise_op: str,
-        esys: Tuple[np.ndarray, np.ndarray] = None,
-        get_rate: bool = False,
-        **kwargs
-        ) -> float:
-        """
-        Calculates the 1/f dephasing time (or rate) due to an arbitrary noise source.
-
-        Parameters
-        ----------
-        A_noise : float
-            Noise strength.
-        i : int
-            State index that along with j defines a qubit.
-        j : int
-            State index that along with i defines a qubit.
-        noise_op : str
-            Name of the noise operator, typically Hamiltonian derivative w.r.t. noisy parameter.
-        esys : Tuple[np.ndarray, np.ndarray], optional
-            Precomputed eigenvalues and eigenvectors (default is None).
-        get_rate : bool, optional
-            Whether to return the rate instead of the Tphi time (default is False).
-
-        Returns
-        -------
-        float
-            The 1/f dephasing time (or rate).
-        """
-        p = {"omega_ir": 2 * np.pi * 1, "omega_uv": 3 * 2 * np.pi * 1e6, "t_exp": 10e-6}
-        p.update(kwargs)
-                
-        if esys is None:
-            evals, evecs = self.eigensys(evals_count=max(j, i) + 1)
-        else:
-            evals, evecs = esys
-
-        noise_operator = getattr(self, noise_op)()    
-        dEij_d_lambda = np.abs(evecs[i].conj().T @ noise_operator @ evecs[i] - evecs[j].conj().T @ noise_operator @ evecs[j])
-
-        rate = (dEij_d_lambda * A_noise * np.sqrt(2 * np.abs(np.log(p["omega_ir"] * p["t_exp"]))))
-        rate *= 2 * np.pi * 1e9 # Convert to rad/s
-
-        return rate if get_rate else 1 / rate
-    
     def tphi_1_over_f_flux(
         self, 
         A_noise: float = 1e-6,

--- a/HybridSuperQubits/ferbo.py
+++ b/HybridSuperQubits/ferbo.py
@@ -2,7 +2,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 from .qubit_base import QubitBase
 from scipy.linalg import cosm, sinm, eigh, expm
-from typing import Any, Dict, Optional, Tuple, Union, Iterable
+from typing import Any, Dict, Optional, Tuple, Union, Iterable, List
 from .operators import destroy, creation, sigma_z, sigma_y, sigma_x
 
 class Ferbo(QubitBase):
@@ -363,13 +363,11 @@ class Ferbo(QubitBase):
     def tphi_1_over_f_flux(
         self, 
         A_noise: float = 1e-6,
-        i: int = 0, 
-        j: int = 1, 
         esys: Tuple[np.ndarray, np.ndarray] = None, 
         get_rate: bool = False, 
         **kwargs
         ) -> float:
-        return self.tphi_1_over_f(A_noise, i, j, 'd_hamiltonian_d_phase', esys=esys, get_rate=get_rate, **kwargs)
+        return self.tphi_1_over_f(A_noise, ['d_hamiltonian_d_phase', 'd2_hamiltonian_d_phase'], esys=esys, get_rate=get_rate, **kwargs)
 
     def plot_wavefunction(
         self, 

--- a/HybridSuperQubits/qubit_base.py
+++ b/HybridSuperQubits/qubit_base.py
@@ -1065,7 +1065,7 @@ class QubitBase(ABC):
         if evals_count is None:
             evals_count = self.dimension
             
-        p = {"omega_ir": 2 * np.pi * 1, "omega_uv": 3 * 2 * np.pi * 1e6, "t_exp": 10e-6}
+        p = {"omega_ir": 2 * np.pi * 1, "omega_uv": 3 * 2 * np.pi * 1e9, "t_exp": 10e-6}
         p.update(kwargs)
         
         if isinstance(noise_operators, str):

--- a/HybridSuperQubits/qubit_base.py
+++ b/HybridSuperQubits/qubit_base.py
@@ -1377,6 +1377,85 @@ class QubitBase(ABC):
             
         return spectrum_data
     
+    def get_d2E_d_param_vs_paramvals(
+        self, 
+        operators: List[str],
+        param_name: str = None, 
+        param_vals: np.ndarray = None, 
+        evals_count: int = None,
+        spectrum_data: SpectrumData = None,
+        **kwargs
+    ) -> SpectrumData:
+        """
+        Calculates the second derivative of energy with respect to a parameter over a range of parameter values.
+
+        Parameters
+        ----------
+        operators : List[str]
+            The operators used to calculate the derivatives. Must contain two elements:
+            First element: first derivative operator (e.g., 'd_hamiltonian_d_phase')
+            Second element: second derivative operator (e.g., 'd2_hamiltonian_d_phase2')
+        param_name : str, optional
+            The name of the parameter to vary.
+        param_vals : np.ndarray, optional
+            The values of the parameter to vary.
+        evals_count : int, optional
+            The number of eigenvalues and eigenstates to calculate (default is None, which uses self.dimension).
+        spectrum_data : SpectrumData, optional
+            Precomputed spectral data to use (default is None).
+
+        Returns
+        -------
+        SpectrumData
+            The spectral data with added second derivatives.
+        """
+        if evals_count is None:
+            evals_count = self.dimension
+            
+        if len(operators) != 2:
+            raise ValueError("operators must contain exactly two elements: first and second derivative operators")
+
+        first_op = operators[0]
+        if 'd_hamiltonian_d_' in first_op:
+            deriv_param = first_op.split('d_hamiltonian_d_')[1]
+        else:
+            raise ValueError("The operators must be of the form 'd_hamiltonian_d_X' and 'd2_hamiltonian_d_X2'.")
+        
+        # Check if spectrum_data has enough eigenvalues
+        if spectrum_data is not None and spectrum_data.energy_table.shape[1] < self.dimension:
+            print(f"Warning: spectrum_data contains only {spectrum_data.energy_table.shape[1]} eigenvalues, but {self.dimension} are needed for accurate second derivative calculation.")
+            print("Recalculating spectrum_data with sufficient eigenvalues...")
+            param_name = spectrum_data.param_name
+            param_vals = spectrum_data.param_vals
+            spectrum_data = None
+
+        if spectrum_data is None:
+            spectrum_data = self.get_matelements_vs_paramvals(operators, param_name, param_vals, evals_count=evals_count)
+        elif not all(op in spectrum_data.matrixelem_table for op in operators):
+            missing_operators = [op for op in operators if op not in spectrum_data.matrixelem_table]
+            new_spec = self.get_matelements_vs_paramvals(missing_operators, param_name, param_vals, evals_count=evals_count)
+            spectrum_data.matrixelem_table.update(new_spec.matrixelem_table)
+
+        param_vals = spectrum_data.param_vals
+        
+        # Calculate diagonal elements of the second derivative operator
+        d2H_d_lambda2 = np.diagonal(spectrum_data.matrixelem_table[operators[1]], axis1=1, axis2=2)
+        
+        # Calculate energy differences
+        E_diff = spectrum_data.energy_table[:, :, np.newaxis] - spectrum_data.energy_table[:, np.newaxis, :]
+        E_diff = np.where(E_diff == 0, np.inf, E_diff)
+        
+        # Calculate the second derivative correction
+        dH_d_lambda_matelems_square = np.abs(spectrum_data.matrixelem_table[operators[0]])**2
+        d2E_d_lambda2_correction = 2 * np.sum(dH_d_lambda_matelems_square / E_diff, axis=2)
+        
+        # Calculate the total second derivative
+        d2E_d_lambda2 = d2H_d_lambda2 + d2E_d_lambda2_correction
+        
+        spectrum_data.d2E_table[f'd2E_d_{deriv_param}2'] = np.real(d2E_d_lambda2)
+        
+        return spectrum_data
+    
     def plot_evals_vs_paramvals(
         self, 
         param_name: str = None,
@@ -1746,82 +1825,3 @@ class QubitBase(ABC):
             for param, label in self.PARAM_LABELS.items()
         ]
         return ', '.join(filter(None, title_parts))
-    
-    def get_d2E_d_param_vs_paramvals(
-        self, 
-        operators: List[str],
-        param_name: str = None, 
-        param_vals: np.ndarray = None, 
-        evals_count: int = None,
-        spectrum_data: SpectrumData = None,
-        **kwargs
-    ) -> SpectrumData:
-        """
-        Calculates the second derivative of energy with respect to a parameter over a range of parameter values.
-
-        Parameters
-        ----------
-        operators : List[str]
-            The operators used to calculate the derivatives. Must contain two elements:
-            First element: first derivative operator (e.g., 'd_hamiltonian_d_phase')
-            Second element: second derivative operator (e.g., 'd2_hamiltonian_d_phase2')
-        param_name : str, optional
-            The name of the parameter to vary.
-        param_vals : np.ndarray, optional
-            The values of the parameter to vary.
-        evals_count : int, optional
-            The number of eigenvalues and eigenstates to calculate (default is None, which uses self.dimension).
-        spectrum_data : SpectrumData, optional
-            Precomputed spectral data to use (default is None).
-
-        Returns
-        -------
-        SpectrumData
-            The spectral data with added second derivatives.
-        """
-        if evals_count is None:
-            evals_count = self.dimension
-            
-        if len(operators) != 2:
-            raise ValueError("operators must contain exactly two elements: first and second derivative operators")
-
-        first_op = operators[0]
-        if 'd_hamiltonian_d_' in first_op:
-            deriv_param = first_op.split('d_hamiltonian_d_')[1]
-        else:
-            raise ValueError("The operators must be of the form 'd_hamiltonian_d_X' and 'd2_hamiltonian_d_X2'.")
-        
-        # Check if spectrum_data has enough eigenvalues
-        if spectrum_data is not None and spectrum_data.energy_table.shape[1] < self.dimension:
-            print(f"Warning: spectrum_data contains only {spectrum_data.energy_table.shape[1]} eigenvalues, but {self.dimension} are needed for accurate second derivative calculation.")
-            print("Recalculating spectrum_data with sufficient eigenvalues...")
-            param_name = spectrum_data.param_name
-            param_vals = spectrum_data.param_vals
-            spectrum_data = None
-
-        if spectrum_data is None:
-            spectrum_data = self.get_matelements_vs_paramvals(operators, param_name, param_vals, evals_count=evals_count)
-        elif not all(op in spectrum_data.matrixelem_table for op in operators):
-            missing_operators = [op for op in operators if op not in spectrum_data.matrixelem_table]
-            new_spec = self.get_matelements_vs_paramvals(missing_operators, param_name, param_vals, evals_count=evals_count)
-            spectrum_data.matrixelem_table.update(new_spec.matrixelem_table)
-
-        param_vals = spectrum_data.param_vals
-        
-        # Calculate diagonal elements of the second derivative operator
-        d2H_d_lambda2 = np.diagonal(spectrum_data.matrixelem_table[operators[1]], axis1=1, axis2=2)
-        
-        # Calculate energy differences
-        E_diff = spectrum_data.energy_table[:, :, np.newaxis] - spectrum_data.energy_table[:, np.newaxis, :]
-        E_diff = np.where(E_diff == 0, np.inf, E_diff)
-        
-        # Calculate the second derivative correction
-        dH_d_lambda_matelems_square = np.abs(spectrum_data.matrixelem_table[operators[0]])**2
-        d2E_d_lambda2_correction = 2 * np.sum(dH_d_lambda_matelems_square / E_diff, axis=2)
-        
-        # Calculate the total second derivative
-        d2E_d_lambda2 = d2H_d_lambda2 + d2E_d_lambda2_correction
-        
-        spectrum_data.d2E_table[f'd2E_d_{deriv_param}2'] = np.real(d2E_d_lambda2)
-        
-        return spectrum_data


### PR DESCRIPTION
- Allows to calculate the rate of relaxation, absortion or the total contribution.
- Move method `tphi_&_over_f` and `tphi_CQPS` to `qubit_base.py`.
- Fix bug of setting wrong value in `omega_uv` for dephasing estimations.
- Small refactors.