### PR TITLE
refactor!: extract noise sweep dispatchers; reconcile physics to sweep path (#17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 ## [Unreleased]
 
+## [v0.12.0] - 2026-05-16
+### New Features
+- Extended `HybridSuperQubits.noise` with table-level sweep functions:
+  `t1_table_from_spectral_density`, `tphi_1_over_f_table`, `tphi_cqps_table`.
+  Channel-specific spectral densities (`S_capacitive`, `S_inductive`,
+  `S_flux_bias_line`, `S_charge_impedance`, `S_one_over_f_flux`,
+  `S_critical_current`, `S_andreev`) are now public — a single source of truth
+  shared by both the single-shot and sweep code paths.
+- The 7 `get_t1_*_vs_paramvals` methods, 2 `get_tphi_*_vs_paramvals` methods,
+  `get_tphi_CQPS_vs_paramvals`, and the internal `_get_t1_vs_paramvals` /
+  `_get_tphi_1_over_f_vs_paramvals` dispatchers on `QubitBase` are now thin
+  wrappers around these functions. Phase B of the #17 refactor.
+
+### Breaking Changes
+- **Reconciled single-shot vs sweep physics divergences.** The single-shot
+  `t1_capacitive`, `t1_inductive`, and `t1_flux_bias_line` methods (and the
+  corresponding `HybridSuperQubits.noise` functions) now produce the same
+  numerical results as their sweep counterparts. Previously they differed by
+  factors of ~2 (capacitive) and used a different formula entirely
+  (flux-bias-line). The sweep version was the physically correct one and is
+  now the single source of truth.
+- Removed the `total: bool` keyword argument from `t1_capacitive`,
+  `t1_inductive`, `t1_flux_bias_line` (both class methods and standalone
+  functions) and from `get_t1_*_vs_paramvals` sweep methods. The kwarg was
+  the knob that selected the buggy "SD(+ω) + SD(-ω)" summing in single-shot;
+  with the physics reconciled there is no longer a switch to flip. Passing
+  `total=...` will raise `TypeError`.
+
+### Bug Fixes
+- Capacitive single-shot T1 prefactor corrected from 8 to 16 to match the
+  sweep path. Combined with the v0.11.0 `Q_cap` default fix, single-shot
+  capacitive T1 values are now consistent with sweep values for the same
+  parameters.
+
 ## [v0.11.0] - 2026-05-16
 ### New Features
 - Added `HybridSuperQubits.noise` module: standalone pure functions for the existing

--- a/HybridSuperQubits/noise.py
+++ b/HybridSuperQubits/noise.py
@@ -5,7 +5,20 @@ parameters — no qubit object required. The class methods on
 :class:`HybridSuperQubits.qubit_base.QubitBase` are thin wrappers that
 resolve state from ``self`` and delegate to these functions.
 
-This is Phase A of the functional refactor proposed in issue #17.
+Two layers:
+
+* **Single-shot** functions (``t1_capacitive``, ``t1_inductive``, ``t1_flux_bias_line``,
+  ``tphi_1_over_f``, ``tphi_CQPS``) take eigenvalues/matrix-elements at one
+  parameter value and return a single rate or one (n_eval, n_eval) Tphi matrix.
+* **Sweep / table** functions (``t1_table_from_spectral_density``,
+  ``tphi_1_over_f_table``, ``tphi_cqps_table``) consume the full
+  ``(n_param, n_eval[, n_eval])`` tables produced by a parameter sweep and
+  return a ``t1_table`` / ``tphi_table`` of the same shape.
+
+Both layers share the same channel-specific spectral densities (``S_capacitive``,
+``S_inductive``, ``S_flux_bias_line``, ``S_charge_impedance``, ``S_one_over_f_flux``,
+``S_critical_current``, ``S_andreev``) — a single source of truth for the
+physics.
 """
 
 from __future__ import annotations
@@ -17,14 +30,35 @@ from scipy.constants import e, h, hbar, k
 from scipy.special import k0
 
 __all__ = [
+    "R_Q",
+    # spectral densities
+    "S_capacitive",
+    "S_inductive",
+    "S_flux_bias_line",
+    "S_charge_impedance",
+    "S_one_over_f_flux",
+    "S_critical_current",
+    "S_andreev",
+    # default Q factories
+    "default_Q_cap",
+    "default_Q_ind_factory",
+    # helpers
     "transition_omega",
+    # single-shot
     "t1_from_spectral_density",
     "t1_capacitive",
     "t1_inductive",
     "t1_flux_bias_line",
     "tphi_1_over_f",
     "tphi_CQPS",
+    # sweep / table
+    "t1_table_from_spectral_density",
+    "tphi_1_over_f_table",
+    "tphi_cqps_table",
 ]
+
+
+R_Q = h / (2 * e) ** 2  # Superconducting resistance quantum
 
 
 # ---------------------------------------------------------------------------
@@ -57,23 +91,54 @@ def _resolve_q_factor(
 
 
 # ---------------------------------------------------------------------------
-# Spectral densities (private)
+# Default quality-factor models
 # ---------------------------------------------------------------------------
 
 
-def _S_capacitive(
+def default_Q_cap(omega: np.ndarray) -> np.ndarray:
+    """Default capacitive quality factor: ``(1/3e-5) (2π·6e9 / |ω|)**0.7``."""
+    return 1 / 3e-5 * (2 * np.pi * 6e9 / np.abs(omega)) ** 0.7
+
+
+def default_Q_ind_factory(T: float) -> Callable[[np.ndarray], np.ndarray]:
+    """Build the temperature-dependent default ``Q_ind(omega)``.
+
+    Q_ind = 500e6 · q_ind(ω) / q_ind(ω_ref) with q_ind(ω) = 1 / (k0(x) sinh(x))
+    and ω_ref = 2π · 0.5 GHz.
+    """
+    Q_ind_ref = 500e6
+    omega_ref = 2 * np.pi * 0.5e9
+
+    def q_ind(omega: np.ndarray) -> np.ndarray:
+        x = (hbar * np.abs(omega)) / (2 * k * T)
+        return 1 / (k0(x) * np.sinh(x))
+
+    def Q_ind(omega: np.ndarray) -> np.ndarray:
+        return Q_ind_ref * q_ind(omega) / q_ind(omega_ref)
+
+    return Q_ind
+
+
+# ---------------------------------------------------------------------------
+# Spectral densities — single source of truth, shared by single-shot and
+# sweep functions. Formulas follow the sweep-path conventions (the
+# physically consistent ones).
+# ---------------------------------------------------------------------------
+
+
+def S_capacitive(
     omega: np.ndarray, T: float, Ec: float,
     Q_cap: Callable[[np.ndarray], np.ndarray],
 ) -> np.ndarray:
     x = hbar * omega / (k * T)
     return (
-        8 * Ec / Q_cap(omega)
+        16 * Ec / Q_cap(omega)
         * 1 / np.tanh(np.abs(x) / 2)
         / (1 + np.exp(-x))
     )
 
 
-def _S_inductive(
+def S_inductive(
     omega: np.ndarray, T: float, El: float,
     Q_ind: Callable[[np.ndarray], np.ndarray],
 ) -> np.ndarray:
@@ -85,46 +150,50 @@ def _S_inductive(
     )
 
 
-def _S_flux_bias_line(
+def S_flux_bias_line(
     omega: np.ndarray, T: float, M: float, Z: float,
 ) -> np.ndarray:
     x = hbar * omega / (k * T)
     return (
-        4 * np.pi**2 * M**2 * np.abs(omega) * 1e9 * h / Z
-        * (1 + 1 / np.tanh(np.abs(x)) / 2)
+        4 * np.pi**2 * M**2 * omega * 1e9 * h / Z
+        * (1 + 1 / np.tanh(x / 2))
+    )
+
+
+def S_charge_impedance(
+    omega: np.ndarray, T: float, Z: float,
+) -> np.ndarray:
+    x = hbar * omega / (k * T)
+    return (
+        omega / 1e9 / R_Q * Z
+        * (1 + 1 / np.tanh(np.abs(x) / 2))
         / (1 + np.exp(-x))
     )
 
 
-def _default_Q_cap(omega: np.ndarray) -> np.ndarray:
-    # 1/3e-5 ~= 3.33e4 is the physically correct prefactor; the previous
-    # single-shot t1_capacitive used 1e6, which underestimated the
-    # capacitive rate by ~30x. The sweep path get_t1_capacitive_vs_paramvals
-    # already used this value.
-    return 1 / 3e-5 * (2 * np.pi * 6e9 / np.abs(omega)) ** 0.7
+def S_one_over_f_flux(
+    omega: np.ndarray, T: float, A_noise: float,
+) -> np.ndarray:
+    del T  # not used; kept for dispatcher signature symmetry
+    return 2 * np.pi * A_noise**2 / np.abs(omega)
 
 
-def _default_Q_ind_factory(T: float) -> Callable[[np.ndarray], np.ndarray]:
-    """Build the default inductive Q(omega) at temperature T.
+def S_critical_current(
+    omega: np.ndarray, T: float, A_noise: float, El: float, N: int,
+) -> np.ndarray:
+    del T
+    return 2 * np.pi * (A_noise * El / np.sqrt(N)) ** 2 / omega * 1e9
 
-    Reproduces the original behavior in ``QubitBase.t1_inductive``: the
-    reference value uses ``h * 0.5e9`` (not ``hbar``), preserved here
-    verbatim.
-    """
-    def Q_ind(omega: np.ndarray) -> np.ndarray:
-        return 500e6 * (
-            k0(h * 0.5e9 / (2 * k * T))
-            * np.sinh(h * 0.5e9 / (2 * k * T))
-            / (
-                k0(hbar * np.abs(omega) / (2 * k * T))
-                * np.sinh(hbar * np.abs(omega) / (2 * k * T))
-            )
-        )
-    return Q_ind
+
+def S_andreev(
+    omega: np.ndarray, T: float, R: float,
+) -> np.ndarray:
+    x = hbar * omega / (k * T)
+    return R * omega / 1e9 / 4 / R_Q * (1 + 1 / np.tanh(x / 2))
 
 
 # ---------------------------------------------------------------------------
-# Generic T1
+# Single-shot T1
 # ---------------------------------------------------------------------------
 
 
@@ -135,44 +204,17 @@ def t1_from_spectral_density(
     T: float,
     i: int = 1,
     j: int = 0,
-    total: bool = True,
     get_rate: bool = False,
 ) -> float:
-    """Generic T1 formula given a spectral density and operator matrix elements.
+    """Generic T1 for one transition.
 
-    Parameters
-    ----------
-    evals
-        Eigenvalues in GHz.
-    matrix_elements
-        Operator matrix in the eigenbasis. Only ``matrix_elements[i, j]`` is
-        used.
-    spectral_density
-        Callable ``S(omega, T) -> array``. ``omega`` is in rad/s, ``T`` in K.
-    T
-        Temperature in K.
-    i, j
-        Transition indices.
-    total
-        If ``True``, sum the spectral density at ``+omega`` and ``-omega``
-        (relaxation + excitation).
-    get_rate
-        If ``True``, return the rate (1/s) instead of T1 (s).
+    rate = 2π · |M_ij|² · S(ω_ij, T) · 1e9, T1 = 1/rate.
     """
     omega = transition_omega(evals, i, j)
-    s = (
-        spectral_density(omega, T) + spectral_density(-omega, T)
-        if total
-        else spectral_density(omega, T)
-    )
+    s = spectral_density(omega, T)
     matrix_element = np.abs(matrix_elements[i, j])
     rate = 2 * np.pi * matrix_element**2 * s * 1e9
     return float(rate if get_rate else 1 / rate)
-
-
-# ---------------------------------------------------------------------------
-# Channel-specific T1 functions
-# ---------------------------------------------------------------------------
 
 
 def t1_capacitive(
@@ -183,32 +225,16 @@ def t1_capacitive(
     Q_cap: Optional[Union[float, Callable]] = None,
     i: int = 1,
     j: int = 0,
-    total: bool = True,
     get_rate: bool = False,
 ) -> float:
-    """T1 from capacitive (charge) noise.
-
-    Parameters
-    ----------
-    evals
-        Eigenvalues in GHz.
-    n_op_matelems
-        Number operator matrix elements in the eigenbasis.
-    Ec
-        Charging energy in GHz.
-    T
-        Temperature in K.
-    Q_cap
-        Capacitive quality factor — a float, a callable ``Q(omega)``, or
-        ``None`` for the default ``1e6 * (2*pi*6e9 / |omega|)**0.7``.
-    """
-    Q_cap_fun = _resolve_q_factor(Q_cap, _default_Q_cap)
+    """T1 from capacitive (charge) noise."""
+    Q_cap_fun = _resolve_q_factor(Q_cap, default_Q_cap)
 
     def sd(omega, temp):
-        return _S_capacitive(omega, temp, Ec, Q_cap_fun)
+        return S_capacitive(omega, temp, Ec, Q_cap_fun)
 
     return t1_from_spectral_density(
-        evals, n_op_matelems, sd, T, i=i, j=j, total=total, get_rate=get_rate,
+        evals, n_op_matelems, sd, T, i=i, j=j, get_rate=get_rate,
     )
 
 
@@ -220,17 +246,16 @@ def t1_inductive(
     Q_ind: Optional[Union[float, Callable]] = None,
     i: int = 1,
     j: int = 0,
-    total: bool = True,
     get_rate: bool = False,
 ) -> float:
     """T1 from inductive (flux) noise."""
-    Q_ind_fun = _resolve_q_factor(Q_ind, _default_Q_ind_factory(T))
+    Q_ind_fun = _resolve_q_factor(Q_ind, default_Q_ind_factory(T))
 
     def sd(omega, temp):
-        return _S_inductive(omega, temp, El, Q_ind_fun)
+        return S_inductive(omega, temp, El, Q_ind_fun)
 
     return t1_from_spectral_density(
-        evals, phase_op_matelems, sd, T, i=i, j=j, total=total, get_rate=get_rate,
+        evals, phase_op_matelems, sd, T, i=i, j=j, get_rate=get_rate,
     )
 
 
@@ -242,21 +267,20 @@ def t1_flux_bias_line(
     T: float = 0.015,
     i: int = 1,
     j: int = 0,
-    total: bool = True,
     get_rate: bool = False,
 ) -> float:
     """T1 from flux-bias-line noise."""
 
     def sd(omega, temp):
-        return _S_flux_bias_line(omega, temp, M, Z)
+        return S_flux_bias_line(omega, temp, M, Z)
 
     return t1_from_spectral_density(
-        evals, dH_dphase_matelems, sd, T, i=i, j=j, total=total, get_rate=get_rate,
+        evals, dH_dphase_matelems, sd, T, i=i, j=j, get_rate=get_rate,
     )
 
 
 # ---------------------------------------------------------------------------
-# Tphi
+# Single-shot Tphi
 # ---------------------------------------------------------------------------
 
 
@@ -277,21 +301,18 @@ def tphi_1_over_f(
     evals
         Eigenvalues in GHz.
     dH_dlambda_matelems
-        First-derivative operator in the eigenbasis. Both its diagonal
-        (1st-order term) and off-diagonal elements (2nd-order correction)
-        are used.
+        First-derivative operator in the eigenbasis.
     A_noise
         Noise amplitude.
     d2H_dlambda2_op
         Optional second-derivative operator in the *original* basis (its
-        diagonal is taken internally). Preserves the original API behavior
-        of ``QubitBase.tphi_1_over_f``: the bare diagonal is used for the
-        2nd-order term, with a perturbative correction from
-        ``dH_dlambda_matelems``.
+        diagonal is taken internally). NOTE: this is an operator-based
+        approximation to d²E/dλ². The sweep-path
+        :func:`tphi_1_over_f_table` accepts an already-computed *numerical*
+        d²E table (via ``QubitBase.get_d2E_d_param_vs_paramvals``), which is
+        the physically preferred route when a parameter sweep is available.
     omega_ir, omega_uv, t_exp
         Noise-spectrum cutoffs and experiment duration.
-    get_rate
-        If ``True``, return rates (rad/s); otherwise Tphi (s).
     """
     dH_d_lambda = dH_dlambda_matelems
     dE_d_lambda = np.real(np.diagonal(dH_d_lambda))
@@ -340,23 +361,8 @@ def tphi_CQPS(
     z: float = 0.05,
     get_rate: bool = False,
 ) -> np.ndarray:
-    """Coherent Quantum Phase Slip dephasing.
-
-    Parameters
-    ----------
-    evals
-        Eigenvalues in GHz (unused by the formula but kept for signature
-        symmetry with the other Tphi function).
-    displacement_op_matelems
-        Displacement operator in the eigenbasis.
-    El
-        Inductive energy in GHz.
-    fp
-        Plasma frequency (Hz).
-    z
-        Normalized impedance ``Z / R_Q``.
-    """
-    del evals  # not used; kept for API symmetry
+    """Coherent Quantum Phase Slip dephasing for a single parameter value."""
+    del evals  # not used by the CQPS formula
 
     phase_slip_frequency = (
         4 * np.sqrt(2) / np.pi * fp / np.sqrt(z) * np.exp(-4 / np.pi / z)
@@ -371,10 +377,157 @@ def tphi_CQPS(
         * np.abs(structure_factor)
     )
     rate = np.where(rate == 0, np.inf, rate)
-
     return np.asarray(rate if get_rate else 1 / rate)
 
 
-# Re-export constants used by callers building custom spectral densities.
-__all__ += ["R_Q"]
-R_Q = h / (2 * e) ** 2
+# ---------------------------------------------------------------------------
+# Sweep / table-level T1
+# ---------------------------------------------------------------------------
+
+
+def t1_table_from_spectral_density(
+    evals_table: np.ndarray,
+    matelems_table: np.ndarray,
+    spectral_density: Callable[[np.ndarray, float], np.ndarray],
+    T: float,
+    min_freq_cutoff_ghz: float = 1e-9,
+    max_freq_cutoff_ghz: float = 80.0,
+) -> np.ndarray:
+    """T1 table from sweep-level eigenvalues and operator matrix elements.
+
+    Parameters
+    ----------
+    evals_table
+        Shape ``(n_param, n_eval)``. Eigenvalues in GHz.
+    matelems_table
+        Shape ``(n_param, n_eval, n_eval)``. Operator matrix elements in the
+        eigenbasis at every parameter value.
+    spectral_density
+        Callable ``S(omega, T) -> array`` evaluated on the full transition
+        frequency grid (``omega`` in rad/s).
+    T
+        Temperature in K.
+    min_freq_cutoff_ghz, max_freq_cutoff_ghz
+        Transition-frequency band (GHz). Transitions outside the band have
+        their T1 set to NaN.
+    """
+    transitions = (
+        evals_table[:, :, np.newaxis] - evals_table[:, np.newaxis, :]
+    )
+    transitions = np.where(
+        np.abs(transitions) < min_freq_cutoff_ghz, np.nan, transitions,
+    )
+    transitions = np.where(
+        np.abs(transitions) > max_freq_cutoff_ghz, np.nan, transitions,
+    )
+
+    omega = 2 * np.pi * transitions * 1e9
+    s = spectral_density(omega, T)
+
+    rate = 2 * np.pi * np.abs(matelems_table) ** 2 * s
+    rate *= 1e9
+    rate = np.where(rate == 0, np.nan, rate)
+    t1_table = 1 / rate
+
+    for idx in range(t1_table.shape[0]):
+        np.fill_diagonal(t1_table[idx], np.nan)
+    return t1_table
+
+
+# ---------------------------------------------------------------------------
+# Sweep / table-level Tphi
+# ---------------------------------------------------------------------------
+
+
+def tphi_1_over_f_table(
+    dE_d_lambda_table: np.ndarray,
+    A_noise: float,
+    d2E_d_lambda2_table: Optional[np.ndarray] = None,
+    omega_ir: float = 2 * np.pi,
+    omega_uv: float = 3 * 2 * np.pi * 1e9,
+    t_exp: float = 10e-6,
+) -> np.ndarray:
+    """1/f dephasing table from per-parameter energy derivatives.
+
+    Unlike the single-shot :func:`tphi_1_over_f` (which can fall back to an
+    operator-diagonal approximation for d²E/dλ²), this table function
+    consumes the *numerical* d²E/dλ² from a finite-difference sweep
+    (computed upstream by ``QubitBase.get_d2E_d_param_vs_paramvals``).
+
+    Parameters
+    ----------
+    dE_d_lambda_table
+        Shape ``(n_param, n_eval)``. The diagonal of the dH/dλ matrix
+        elements in the eigenbasis at every parameter value.
+    A_noise
+        Noise amplitude.
+    d2E_d_lambda2_table
+        Shape ``(n_param, n_eval)``. If supplied, adds the 2nd-order term.
+    """
+    dEij = (
+        dE_d_lambda_table[:, :, np.newaxis]
+        - dE_d_lambda_table[:, np.newaxis, :]
+    )
+    rate_1st = (
+        np.abs(dEij) * A_noise
+        * np.sqrt(2 * np.abs(np.log(omega_ir * t_exp)))
+    )
+
+    if d2E_d_lambda2_table is not None:
+        d2Eij = (
+            d2E_d_lambda2_table[:, :, np.newaxis]
+            - d2E_d_lambda2_table[:, np.newaxis, :]
+        )
+        rate_2nd = (
+            np.abs(d2Eij) * A_noise**2
+            * np.sqrt(
+                2 * np.log(omega_uv / omega_ir) ** 2
+                + 2 * np.log(omega_ir * t_exp) ** 2
+            )
+        )
+    else:
+        rate_2nd = 0
+
+    rate = np.sqrt(rate_1st**2 + rate_2nd**2)
+    rate = np.where(rate == 0, 1e-12, rate)
+    rate *= 2 * np.pi * 1e9
+    tphi_table = 1 / rate
+
+    for idx in range(tphi_table.shape[0]):
+        np.fill_diagonal(tphi_table[idx], np.nan)
+    return tphi_table
+
+
+def tphi_cqps_table(
+    displacement_op_matelems_table: np.ndarray,
+    El_values: np.ndarray,
+    fp: float = 17e9,
+    z: float = 0.05,
+) -> np.ndarray:
+    """CQPS dephasing table for a parameter sweep.
+
+    Parameters
+    ----------
+    displacement_op_matelems_table
+        Shape ``(n_param, n_eval, n_eval)``. Displacement operator matrix
+        elements at every parameter value.
+    El_values
+        Shape ``(n_param,)``. Inductive energy at each parameter value (for
+        sweeps of ``param_name != "El"`` this is a constant array).
+    """
+    diag = np.diagonal(displacement_op_matelems_table, axis1=1, axis2=2)
+    structure_factor = diag[:, :, np.newaxis] - diag[:, np.newaxis, :]
+
+    phase_slip_frequency = (
+        4 * np.sqrt(2) / np.pi * fp / np.sqrt(z) * np.exp(-4 / np.pi / z)
+    )
+    N_junctions = fp / 2 / np.pi / (El_values * 1e9) / z
+
+    rate = (
+        np.pi
+        * np.sqrt(N_junctions)[:, np.newaxis, np.newaxis]
+        * phase_slip_frequency
+        * np.abs(structure_factor)
+    )
+    rate = np.where(rate == 0, np.inf, rate)
+    return 1 / rate

--- a/HybridSuperQubits/qubit_base.py
+++ b/HybridSuperQubits/qubit_base.py
@@ -4,15 +4,14 @@ from typing import Any, Callable, Literal, Optional, Union
 
 import matplotlib.pyplot as plt
 import numpy as np
-from scipy.constants import e, h, hbar, k
 from scipy.linalg import eigh, expm
-from scipy.special import factorial, k0, pbdv
+from scipy.special import factorial, pbdv
 from tqdm.notebook import tqdm
 
 from . import noise as _noise
 from .storage import SpectrumData
 
-R_Q = h / (2 * e) ** 2  # Superconducting resistance quantum
+R_Q = _noise.R_Q  # Superconducting resistance quantum
 
 
 class QubitBase(ABC):
@@ -397,13 +396,10 @@ class QubitBase(ABC):
         j: int = 0,
         Q_cap: Optional[Union[float, Callable]] = None,
         T: float = 0.015,
-        total: bool = True,
         esys: Optional[tuple[np.ndarray, np.ndarray]] = None,
         matrix_elements: Optional[np.ndarray] = None,
         get_rate: bool = False,
-        noise_op: Optional[np.ndarray] = None,
     ) -> float:
-        del noise_op  # preserved for API compat; previously unused after lookup
         if esys is None:
             evals, evecs = self.eigensys(evals_count=max(i, j) + 1)
         else:
@@ -420,7 +416,6 @@ class QubitBase(ABC):
             Q_cap=Q_cap,
             i=i,
             j=j,
-            total=total,
             get_rate=get_rate,
         )
 
@@ -430,7 +425,6 @@ class QubitBase(ABC):
         j: int = 0,
         Q_ind: Optional[float] = None,
         T: float = 0.015,
-        total: bool = True,
         esys: Optional[tuple[np.ndarray, np.ndarray]] = None,
         matrix_elements: Optional[np.ndarray] = None,
         get_rate: bool = False,
@@ -451,7 +445,6 @@ class QubitBase(ABC):
             Q_ind=Q_ind,
             i=i,
             j=j,
-            total=total,
             get_rate=get_rate,
         )
 
@@ -462,7 +455,6 @@ class QubitBase(ABC):
         M: float = 2500,
         Z: float = 50,
         T: float = 0.015,
-        total: bool = True,
         esys: Optional[tuple[np.ndarray, np.ndarray]] = None,
         matrix_elements: Optional[np.ndarray] = None,
         get_rate: bool = False,
@@ -483,7 +475,6 @@ class QubitBase(ABC):
             T=T,
             i=i,
             j=j,
-            total=total,
             get_rate=get_rate,
         )
 
@@ -674,96 +665,23 @@ class QubitBase(ABC):
         spectrum_data: Optional[SpectrumData] = None,
         Q_cap: Optional[Union[float, Callable]] = None,
         T: float = 0.015,
-        total: bool = True,
         **kwargs,
     ) -> SpectrumData:
-        """
-        Calculates the T1 times for capacitive noise over a range of parameter values.
-
-        Parameters
-        ----------
-        param_name : str, optional
-            The name of the parameter to vary.
-        param_vals : np.ndarray, optional
-            The values of the parameter to vary.
-        evals_count : int, optional
-            The number of eigenvalues and eigenstates to calculate (default is None, in which case all are calculated).
-        spectrum_data : SpectrumData, optional
-            Precomputed spectral data to use (default is None).
-        Q_cap : Union[float, Callable], optional
-            The capacitance quality factor or a function that returns it (default is None).
-        T : float, optional
-            The temperature (default is 0.015).
-        **kwargs
-            Additional arguments to pass to the T1 calculation method.
-
-        Returns
-        -------
-        SpectrumData
-            The T1 times for capacitive noise over the range of parameter values.
-        """
-        if evals_count is None:
-            evals_count = self.dimension
-
-        # Validate required parameters
-        if spectrum_data is not None:
-            param_name = spectrum_data.param_name
-            param_vals = spectrum_data.param_vals
-            evals_count = spectrum_data.energy_table.shape[1]
-        elif param_name is None or param_vals is None:
-            raise ValueError(
-                "If spectrum_data is None, param_name and param_vals must be provided."
+        """T1 times for capacitive noise over a parameter sweep."""
+        param_name, param_vals, evals_count, spectrum_data = (
+            self._resolve_sweep_inputs(
+                param_name, param_vals, evals_count, spectrum_data,
             )
-
-        # After validation, these should not be None
-        assert param_name is not None
-        assert param_vals is not None
-
-        # Create spectrum_data if not provided
-        if spectrum_data is None:
-            spectrum_data = self.get_spectrum_vs_paramvals(
-                param_name, param_vals, evals_count=evals_count
-            )
-
-        if Q_cap is None:
-
-            def Q_cap_fun(omega):
-                return (
-                    1/3e-5 * (2 * np.pi * 6e9 / np.abs(omega)) ** 0.7
-                )  # Assuming that Ec is in GHz
-        elif callable(Q_cap):
-            Q_cap_fun = Q_cap
-        else:
-
-            def Q_cap_fun(omega):
-                return Q_cap
+        )
+        Q_cap_fun = _noise._resolve_q_factor(Q_cap, _noise.default_Q_cap)
+        Ec = getattr(self, "Ec", 1.0)
 
         def spectral_density(omega, T):
-            # Assuming that Ec is in GHz
-            x = hbar * omega / (k * T)
-            return (
-                16
-                * getattr(self, "Ec", 1.0)  # Default value for base class
-                / Q_cap_fun(omega)
-                * 1
-                / np.tanh(np.abs(x) / 2)
-                / (1 + np.exp(-x))
-            )
-
-        noise_operator = "n_operator"
-        noise_channel = "capacitive"
+            return _noise.S_capacitive(omega, T, Ec, Q_cap_fun)
 
         return self._get_t1_vs_paramvals(
-            param_name,
-            param_vals,
-            evals_count,
-            spectrum_data,
-            spectral_density,
-            noise_operator,
-            noise_channel,
-            T,
-            total,
-            **kwargs,
+            param_name, param_vals, evals_count, spectrum_data,
+            spectral_density, "n_operator", "capacitive", T, **kwargs,
         )
 
     def get_t1_inductive_vs_paramvals(
@@ -774,102 +692,25 @@ class QubitBase(ABC):
         spectrum_data: Optional[SpectrumData] = None,
         Q_ind: Optional[float] = None,
         T: float = 0.015,
-        total: bool = True,
         **kwargs,
     ) -> SpectrumData:
-        """
-        Calculates the T1 times for inductive noise over a range of parameter values.
-
-        Parameters
-        ----------
-        param_name : str, optional
-            The name of the parameter to vary.
-        param_vals : np.ndarray, optional
-            The values of the parameter to vary.
-        evals_count : int, optional
-            The number of eigenvalues and eigenstates to calculate (default is None, in which case all are calculated).
-        spectrum_data : SpectrumData, optional
-            Precomputed spectral data to use (default is None).
-        Q_ind : float, optional
-            The inductance quality factor (default is 500e6).
-        T : float, optional
-            The temperature (default is 0.015).
-        total : bool, optional
-            Whether to calculate the total noise (default is True).
-        **kwargs
-            Additional arguments to pass to the T1 calculation method.
-
-        Returns
-        -------
-        SpectrumData
-            The T1 times for inductive noise over the range of parameter values.
-        """
-        if evals_count is None:
-            evals_count = self.dimension
-
-        # Validate required parameters
-        if spectrum_data is not None:
-            param_name = spectrum_data.param_name
-            param_vals = spectrum_data.param_vals
-            evals_count = spectrum_data.energy_table.shape[1]
-        elif param_name is None or param_vals is None:
-            raise ValueError(
-                "If spectrum_data is None, param_name and param_vals must be provided."
+        """T1 times for inductive noise over a parameter sweep."""
+        param_name, param_vals, evals_count, spectrum_data = (
+            self._resolve_sweep_inputs(
+                param_name, param_vals, evals_count, spectrum_data,
             )
-
-        # After validation, these should not be None
-        assert param_name is not None
-        assert param_vals is not None
-
-        # Create spectrum_data if not provided
-        if spectrum_data is None:
-            spectrum_data = self.get_spectrum_vs_paramvals(
-                param_name, param_vals, evals_count=evals_count
-            )
-
-        if Q_ind is None:
-            Q_ind_ref = 500e6
-            omega_ref = 2 * np.pi * 0.5e9
-
-            def q_ind(omega):
-                x = (hbar * np.abs(omega)) / (2 * k * T)
-                q_ind_inv = k0(x) * np.sinh(x)
-                return 1 / q_ind_inv
-
-            def Q_ind_fun(omega):
-                return Q_ind_ref * q_ind(omega) / q_ind(omega_ref)
-        elif callable(Q_ind):
-            Q_ind_fun = Q_ind
-        else:
-
-            def Q_ind_fun(omega):
-                return Q_ind
+        )
+        Q_ind_fun = _noise._resolve_q_factor(
+            Q_ind, _noise.default_Q_ind_factory(T),
+        )
+        El = getattr(self, "El", 1.0)
 
         def spectral_density(omega, T):
-            x = hbar * omega / (k * T)
-            return (
-                2
-                * getattr(self, "El", 1.0)  # Default value for base class
-                / Q_ind_fun(omega)
-                * 1
-                / np.tanh(np.abs(x) / 2)
-                / (1 + np.exp(-x))
-            )
-
-        noise_operator = "phase_operator"
-        noise_channel = "inductive"
+            return _noise.S_inductive(omega, T, El, Q_ind_fun)
 
         return self._get_t1_vs_paramvals(
-            param_name,
-            param_vals,
-            evals_count,
-            spectrum_data,
-            spectral_density,
-            noise_operator,
-            noise_channel,
-            T,
-            total,
-            **kwargs,
+            param_name, param_vals, evals_count, spectrum_data,
+            spectral_density, "phase_operator", "inductive", T, **kwargs,
         )
 
     def get_t1_charge_impedance_vs_paramvals(
@@ -880,84 +721,21 @@ class QubitBase(ABC):
         spectrum_data: Optional[SpectrumData] = None,
         Z: float = 50,
         T: float = 0.015,
-        total: bool = True,
         **kwargs,
     ) -> SpectrumData:
-        """
-        Calculates the T1 times for charge impedance noise over a range of parameter values.
-
-        Parameters
-        ----------
-        param_name : str, optional
-            The name of the parameter to vary.
-        param_vals : np.ndarray, optional
-            The values of the parameter
-        evals_count : int, optional
-            The number of eigenvalues and eigenstates to calculate (default is None, in which case all are calculated).
-        spectrum_data : SpectrumData, optional
-            Precomputed spectral data to use (default is None).
-        Z : float, optional
-            The impedance (default is 50).
-        T : float, optional
-            The temperature (default is 0.050).
-        total : bool, optional
-            Whether to calculate the total noise (default is True).
-        **kwargs
-
-        Returns
-        -------
-        SpectrumData
-            The T1 times for charge impedance noise over the range of parameter values.
-        """
-        if evals_count is None:
-            evals_count = self.dimension
-
-        # Validate required parameters
-        if spectrum_data is not None:
-            param_name = spectrum_data.param_name
-            param_vals = spectrum_data.param_vals
-            evals_count = spectrum_data.energy_table.shape[1]
-        elif param_name is None or param_vals is None:
-            raise ValueError(
-                "If spectrum_data is None, param_name and param_vals must be provided."
+        """T1 times for charge-impedance noise over a parameter sweep."""
+        param_name, param_vals, evals_count, spectrum_data = (
+            self._resolve_sweep_inputs(
+                param_name, param_vals, evals_count, spectrum_data,
             )
-
-        # After validation, these should not be None
-        assert param_name is not None
-        assert param_vals is not None
-
-        # Create spectrum_data if not provided
-        if spectrum_data is None:
-            spectrum_data = self.get_spectrum_vs_paramvals(
-                param_name, param_vals, evals_count=evals_count
-            )
+        )
 
         def spectral_density(omega, T):
-            Rk = h / ((2 * e) ** 2)
-            x = hbar * omega / (k * T)
-            return (
-                omega
-                / 1e9
-                / Rk
-                * Z
-                * (1 + 1 / np.tanh(np.abs(x) / 2))
-                / (1 + np.exp(-x))
-            )
-
-        noise_operator = "n_operator"
-        noise_channel = "charge_impedance"
+            return _noise.S_charge_impedance(omega, T, Z)
 
         return self._get_t1_vs_paramvals(
-            param_name,
-            param_vals,
-            evals_count,
-            spectrum_data,
-            spectral_density,
-            noise_operator,
-            noise_channel,
-            T,
-            total,
-            **kwargs,
+            param_name, param_vals, evals_count, spectrum_data,
+            spectral_density, "n_operator", "charge_impedance", T, **kwargs,
         )
 
     def get_t1_flux_bias_line_vs_paramvals(
@@ -969,79 +747,22 @@ class QubitBase(ABC):
         M: float = 2500,
         Z: float = 50,
         T: float = 0.015,
-        total: bool = True,
         **kwargs,
     ) -> SpectrumData:
-        """
-        Calculates the T1 times for flux bias line noise over a range of parameter values.
-
-        Parameters
-        ----------
-        param_name : str, optional
-            The name of the parameter to vary.
-        param_vals : np.ndarray, optional
-            The values of the parameter
-        evals_count : int, optional
-            The number of eigenvalues and eigenstates to calculate (default is None, in which case all are calculated).
-        spectrum_data : SpectrumData, optional
-            Precomputed spectral data to use (default is None).
-        M : float, optional
-            The mutual inductance in units of Phi_0/A (default is 2500 Phi_0/A = 5.2 pH).
-        Z : float, optional
-            The impedance (default is 50).
-        T : float, optional
-            The temperature (default is 0.015).
-        total : bool, optional
-            Whether to calculate the total noise (default is True).
-        **kwargs
-            Additional arguments to pass to the T1 calculation method.
-
-        Returns
-        -------
-        SpectrumData
-            The T1 times for flux bias line noise over the range of parameter values.
-        """
-        if evals_count is None:
-            evals_count = self.dimension
-
-        # Validate required parameters
-        if spectrum_data is not None:
-            param_name = spectrum_data.param_name
-            param_vals = spectrum_data.param_vals
-            evals_count = spectrum_data.energy_table.shape[1]
-        elif param_name is None or param_vals is None:
-            raise ValueError(
-                "If spectrum_data is None, param_name and param_vals must be provided."
+        """T1 times for flux-bias-line noise over a parameter sweep."""
+        param_name, param_vals, evals_count, spectrum_data = (
+            self._resolve_sweep_inputs(
+                param_name, param_vals, evals_count, spectrum_data,
             )
-
-        # After validation, these should not be None
-        assert param_name is not None
-        assert param_vals is not None
-
-        # Create spectrum_data if not provided
-        if spectrum_data is None:
-            spectrum_data = self.get_spectrum_vs_paramvals(
-                param_name, param_vals, evals_count=evals_count
-            )
+        )
 
         def spectral_density(omega, T):
-            x = hbar * omega / (k * T)
-            return 4 * np.pi**2 * M**2 * omega * 1e9 * h / Z * (1 + 1 / np.tanh(x / 2))
-
-        noise_operator = "d_hamiltonian_d_phase"
-        noise_channel = "flux_bias_line"
+            return _noise.S_flux_bias_line(omega, T, M, Z)
 
         return self._get_t1_vs_paramvals(
-            param_name,
-            param_vals,
-            evals_count,
-            spectrum_data,
-            spectral_density,
-            noise_operator,
-            noise_channel,
-            T,
-            total,
-            **kwargs,
+            param_name, param_vals, evals_count, spectrum_data,
+            spectral_density, "d_hamiltonian_d_phase", "flux_bias_line",
+            T, **kwargs,
         )
 
     def get_t1_1_over_f_flux_vs_paramvals(
@@ -1053,69 +774,20 @@ class QubitBase(ABC):
         A_noise: float = 1e-6,
         **kwargs,
     ) -> SpectrumData:
-        """
-        Calculates the T1 times for 1/f flux noise over a range of parameter values.
-
-        Parameters
-        ----------
-        param_name : str, optional
-            The name of the parameter to vary.
-        param_vals : np.ndarray, optional
-            The values of the parameter
-        evals_count : int, optional
-            The number of eigenvalues and eigenstates to calculate (default is None, in which case all are calculated).
-        spectrum_data : SpectrumData, optional
-            Precomputed spectral data to use (default is None).
-        A_noise : float, optional
-            The amplitude of the noise (default is 1e-6).
-        **kwargs
-            Additional arguments to pass to the T1 calculation method.
-
-        Returns
-        -------
-        SpectrumData
-            The T1 times for 1/f flux noise over the range of parameter values.
-        """
-        if evals_count is None:
-            evals_count = self.dimension
-
-        # Validate required parameters
-        if spectrum_data is not None:
-            param_name = spectrum_data.param_name
-            param_vals = spectrum_data.param_vals
-            evals_count = spectrum_data.energy_table.shape[1]
-        elif param_name is None or param_vals is None:
-            raise ValueError(
-                "If spectrum_data is None, param_name and param_vals must be provided."
+        """T1 times for 1/f flux noise over a parameter sweep."""
+        param_name, param_vals, evals_count, spectrum_data = (
+            self._resolve_sweep_inputs(
+                param_name, param_vals, evals_count, spectrum_data,
             )
-
-        # After validation, these should not be None
-        assert param_name is not None
-        assert param_vals is not None
-
-        # Create spectrum_data if not provided
-        if spectrum_data is None:
-            spectrum_data = self.get_spectrum_vs_paramvals(
-                param_name, param_vals, evals_count=evals_count
-            )
+        )
 
         def spectral_density(omega, T):
-            return 2 * np.pi * A_noise**2 / np.abs(omega)
+            return _noise.S_one_over_f_flux(omega, T, A_noise)
 
-        noise_operator = "d_hamiltonian_d_phase"
-        noise_channel = "flux_noise"
-
-        T = 0.015
         return self._get_t1_vs_paramvals(
-            param_name,
-            param_vals,
-            evals_count,
-            spectrum_data,
-            spectral_density,
-            noise_operator,
-            noise_channel,
-            T,
-            **kwargs,
+            param_name, param_vals, evals_count, spectrum_data,
+            spectral_density, "d_hamiltonian_d_phase", "flux_noise",
+            T=0.015, **kwargs,
         )
 
     def get_t1_critical_current_vs_paramvals(
@@ -1128,75 +800,21 @@ class QubitBase(ABC):
         N: int = 100,
         **kwargs,
     ) -> SpectrumData:
-        """
-        Calculates the T1 times for critical current noise over a range of parameter values.
-
-        Parameters
-        ----------
-        param_name : str, optional
-            The name of the parameter to vary.
-        param_vals : np.ndarray, optional
-            The values of the parameter to vary.
-        evals_count : int, optional
-            The number of eigenvalues and eigenstates to calculate (default is None, in which case all are calculated).
-        spectrum_data : SpectrumData, optional
-            Precomputed spectral data to use (default is None).
-        A_noise : float, optional
-            The amplitude of the noise (default is 1e-7).
-        N : int, optional
-            The number of junctions (default is 100).
-
-        Returns
-        -------
-        SpectrumData
-            The T1 times for critical current noise over the range of parameter values.
-        """
-        if evals_count is None:
-            evals_count = self.dimension
-
-        # Validate required parameters
-        if spectrum_data is not None:
-            param_name = spectrum_data.param_name
-            param_vals = spectrum_data.param_vals
-            evals_count = spectrum_data.energy_table.shape[1]
-        elif param_name is None or param_vals is None:
-            raise ValueError(
-                "If spectrum_data is None, param_name and param_vals must be provided."
+        """T1 times for critical-current noise over a parameter sweep."""
+        param_name, param_vals, evals_count, spectrum_data = (
+            self._resolve_sweep_inputs(
+                param_name, param_vals, evals_count, spectrum_data,
             )
-
-        # After validation, these should not be None
-        assert param_name is not None
-        assert param_vals is not None
-
-        # Create spectrum_data if not provided
-        if spectrum_data is None:
-            spectrum_data = self.get_spectrum_vs_paramvals(
-                param_name, param_vals, evals_count=evals_count
-            )
+        )
+        El = getattr(self, "El", 1.0)
 
         def spectral_density(omega, T):
-            return (
-                2
-                * np.pi
-                * (A_noise * getattr(self, "El", 1.0) / np.sqrt(N)) ** 2
-                / omega
-                * 1e9
-            )
+            return _noise.S_critical_current(omega, T, A_noise, El, N)
 
-        noise_operator = "d_hamiltonian_d_EL"
-        noise_channel = "critical_current"
-
-        T = 0.015
         return self._get_t1_vs_paramvals(
-            param_name,
-            param_vals,
-            evals_count,
-            spectrum_data,
-            spectral_density,
-            noise_operator,
-            noise_channel,
-            T,
-            **kwargs,
+            param_name, param_vals, evals_count, spectrum_data,
+            spectral_density, "d_hamiltonian_d_EL", "critical_current",
+            T=0.015, **kwargs,
         )
 
     def get_t1_er_vs_paramvals(
@@ -1207,41 +825,34 @@ class QubitBase(ABC):
         spectrum_data: Optional[SpectrumData] = None,
         R: float = 50,
         T: float = 0.015,
-        total: bool = True,
         **kwargs,
     ) -> SpectrumData:
-        """
-        Calculates the T1 times for the Fermi level noise over a range of parameter values.
+        """T1 times for Fermi-level (Andreev) noise over a parameter sweep."""
+        param_name, param_vals, evals_count, spectrum_data = (
+            self._resolve_sweep_inputs(
+                param_name, param_vals, evals_count, spectrum_data,
+            )
+        )
 
-        Parameters
-        ----------
-        param_name : str, optional
-            The name of the parameter to vary.
-        param_vals : np.ndarray, optional
-            The values of the parameter to vary.
-        evals_count : int, optional
-            The number of eigenvalues and eigenstates to calculate (default is 6).
-        spectrum_data : SpectrumData, optional
-            Precomputed spectral data to use (default is None).
-        R : float, optional
-            The resistance (default is 50 Ohms).
-        T : float, optional
-            The temperature (default is 0.015).
-        total : bool, optional
-            Whether to calculate the total noise (default is True).
-        **kwargs
-            Additional arguments to pass to the T1 calculation method.
+        def spectral_density(omega, T):
+            return _noise.S_andreev(omega, T, R)
 
+        return self._get_t1_vs_paramvals(
+            param_name, param_vals, evals_count, spectrum_data,
+            spectral_density, "d_hamiltonian_d_er", "Andreev", T, **kwargs,
+        )
 
-        Returns
-        -------
-        SpectrumData
-            The T1 times for Fermi level noise over the range of parameter values.
-        """
+    def _resolve_sweep_inputs(
+        self,
+        param_name: Optional[str],
+        param_vals: Optional[np.ndarray],
+        evals_count: Optional[int],
+        spectrum_data: Optional[SpectrumData],
+    ) -> tuple[str, np.ndarray, int, SpectrumData]:
+        """Common boilerplate for sweep methods: resolve inputs and ensure
+        ``spectrum_data`` is populated with the eigensystem table."""
         if evals_count is None:
             evals_count = self.dimension
-
-        # Validate required parameters
         if spectrum_data is not None:
             param_name = spectrum_data.param_name
             param_vals = spectrum_data.param_vals
@@ -1250,38 +861,13 @@ class QubitBase(ABC):
             raise ValueError(
                 "If spectrum_data is None, param_name and param_vals must be provided."
             )
-
-        # After validation, these should not be None
         assert param_name is not None
         assert param_vals is not None
-
-        # Create spectrum_data if not provided
         if spectrum_data is None:
             spectrum_data = self.get_spectrum_vs_paramvals(
-                param_name, param_vals, evals_count=evals_count
+                param_name, param_vals, evals_count=evals_count,
             )
-
-        R_Q = h / (2 * e) ** 2
-
-        def spectral_density(omega, T):
-            x = hbar * omega / (k * T)
-            return R * omega / 1e9 / 4 / R_Q * (1 + 1 / np.tanh(x / 2))
-
-        noise_operator = "d_hamiltonian_d_er"
-        noise_channel = "Andreev"
-
-        return self._get_t1_vs_paramvals(
-            param_name,
-            param_vals,
-            evals_count,
-            spectrum_data,
-            spectral_density,
-            noise_operator,
-            noise_channel,
-            T,
-            total,
-            **kwargs,
-        )
+        return param_name, param_vals, evals_count, spectrum_data
 
     def _get_t1_vs_paramvals(
         self,
@@ -1293,55 +879,16 @@ class QubitBase(ABC):
         noise_operator: str,
         noise_channel: str,
         T: float,
-        total: bool = True,
         **kwargs,
     ) -> SpectrumData:
-        """
-        General method to calculate T1 times for a given noise channel over a range of parameter values.
-
-        Parameters
-        ----------
-        param_name : str
-            The name of the parameter to vary.
-        param_vals : np.ndarray
-            The values of the parameter to vary.
-        evals_count : int
-            The number of eigenvalues and eigenstates to calculate.
-        spectrum_data : SpectrumData
-            Precomputed spectral data to use.
-        spectral_density : Callable
-            Function to calculate the spectral density.
-        noise_operator : str
-            The noise operator to use ('n_operator' or 'phase_operator').
-        noise_channel : str
-            The noise channel to use ('capacitive' or 'inductive').
-        T : float
-            The temperature.
-        **kwargs
-            Additional arguments to pass to the T1 calculation method.
-
-        Returns
-        -------
-        SpectrumData
-            The T1 times for the specified noise channel over the range of parameter values.
-        """
-        if spectrum_data is None:
-            # Validate parameters before calling get_matelements_vs_paramvals
-
-            if param_name is None or param_vals is None:
-                raise ValueError("param_name and param_vals cannot be None")
-
-            spectrum_data = self.get_matelements_vs_paramvals(
-                noise_operator, param_name, param_vals, evals_count=evals_count
-            )
-        if noise_operator not in spectrum_data.matrixelem_table:
-            # Validate spectrum_data parameters
-
-            if spectrum_data.param_name is None or spectrum_data.param_vals is None:
-                raise ValueError(
-                    "spectrum_data.param_name and spectrum_data.param_vals cannot be None"
-                )
-
+        """Thin wrapper: ensure ``noise_operator`` matrix elements are in
+        ``spectrum_data``, then delegate to
+        :func:`HybridSuperQubits.noise.t1_table_from_spectral_density`."""
+        del kwargs  # accepted for caller compatibility; no remaining knobs
+        if noise_operator not in spectrum_data.matrixelem_table or (
+            spectrum_data.matrixelem_table[noise_operator].shape[1]
+            != spectrum_data.matrixelem_table[noise_operator].shape[2]
+        ):
             new_spec = self.get_matelements_vs_paramvals(
                 noise_operator,
                 spectrum_data.param_name,
@@ -1350,37 +897,14 @@ class QubitBase(ABC):
             )
             spectrum_data.matrixelem_table.update(new_spec.matrixelem_table)
 
-        # Validate spectrum_data is not None
-
-        if spectrum_data is None:
-            raise ValueError("spectrum_data cannot be None")
-
-        evals_array = spectrum_data.energy_table
-        transition_table = evals_array[:, :, np.newaxis] - evals_array[:, np.newaxis, :]
-
-        min_freq_cutoff = 1e-9  # Minimum frequency in GHz (1 Hz)
-        max_freq_cutoff = 80.0  # Maximum frequency in GHz (80 GHz)
-        transition_table = np.where(
-            np.abs(transition_table) < min_freq_cutoff, np.nan, transition_table
+        spectrum_data.t1_table[noise_channel] = (
+            _noise.t1_table_from_spectral_density(
+                evals_table=spectrum_data.energy_table,
+                matelems_table=spectrum_data.matrixelem_table[noise_operator],
+                spectral_density=spectral_density,
+                T=T,
+            )
         )
-        transition_table = np.where(
-            np.abs(transition_table) > max_freq_cutoff, np.nan, transition_table
-        )
-
-        omega = 2 * np.pi * transition_table * 1e9
-        s = spectral_density(omega, T)
-
-        matrix_element = spectrum_data.matrixelem_table[noise_operator]
-        rate = 2 * np.pi * np.abs(matrix_element) ** 2 * s
-
-        rate *= 1e9  # Convert to rad/s
-        rate = np.where(rate == 0, np.nan, rate)
-        t1_table = 1 / rate
-
-        for idx in range(t1_table.shape[0]):
-            np.fill_diagonal(t1_table[idx], np.nan)
-
-        spectrum_data.t1_table[noise_channel] = t1_table
         return spectrum_data
 
     def _get_tphi_1_over_f_vs_paramvals(
@@ -1394,34 +918,8 @@ class QubitBase(ABC):
         spectrum_data: Optional[SpectrumData] = None,
         **kwargs,
     ) -> SpectrumData:
-        """
-        Calculates the Tphi times for given noise channels over a range of parameter values.
-
-        Parameters
-        ----------
-        param_name : str, optional
-            The name of the parameter to vary. If not provided, extracted from spectrum_data.
-        param_vals : np.ndarray, optional
-            The values of the parameter to vary. If not provided, extracted from spectrum_data.
-        A_noise : float
-            The amplitude of the noise.
-        noise_channel : str
-            The noise channel to calculate ('flux', etc.).
-        noise_operators : Union[str, List[str]]
-            The noise operator(s) to use. The order of the operators must match the order of approximation.
-            i.e. ['d_hamiltonian_d_flux', 'd2_hamiltonian_d_flux2'].
-        evals_count : int, optional
-            The number of eigenvalues and eigenstates to calculate (default is 6).
-        spectrum_data : SpectrumData, optional
-            Precomputed spectral data to use (default is None).
-        **kwargs
-            Additional arguments to pass to the Tphi calculation method.
-
-        Returns
-        -------
-        SpectrumData
-            The Tphi times for the specified noise channels over the range of parameter values.
-        """
+        """Tphi (1/f) sweep wrapper: gather derivatives, delegate to
+        :func:`HybridSuperQubits.noise.tphi_1_over_f_table`."""
         if evals_count is None:
             evals_count = self.dimension
 
@@ -1432,19 +930,15 @@ class QubitBase(ABC):
             noise_operators = [noise_operators]
 
         first_op = noise_operators[0]
-        if "d_hamiltonian_d_" in first_op:
-            deriv_param = first_op.split("d_hamiltonian_d_")[1]
-        else:
+        if "d_hamiltonian_d_" not in first_op:
             raise ValueError("The operator must be of the form 'd_hamiltonian_d_X'")
+        deriv_param = first_op.split("d_hamiltonian_d_")[1]
 
-        # Extract param_name and param_vals from spectrum_data if not provided
         if spectrum_data is not None:
             if param_name is None:
                 param_name = spectrum_data.param_name
             if param_vals is None:
                 param_vals = spectrum_data.param_vals
-
-        # Validate that we have param_name and param_vals from either source
         if param_name is None or param_vals is None:
             raise ValueError(
                 "param_name and param_vals must be provided either as arguments "
@@ -1453,69 +947,47 @@ class QubitBase(ABC):
 
         if spectrum_data is None:
             spectrum_data = self.get_matelements_vs_paramvals(
-                noise_operators, param_name, param_vals, evals_count=evals_count
+                noise_operators, param_name, param_vals, evals_count=evals_count,
             )
-        # Verify if the noise operators are in the matrix elements table
         elif not all(op in spectrum_data.matrixelem_table for op in noise_operators):
-            missing_operators = [
+            missing = [
                 op for op in noise_operators if op not in spectrum_data.matrixelem_table
             ]
             new_spec = self.get_matelements_vs_paramvals(
-                missing_operators, param_name, param_vals, evals_count=evals_count
+                missing, param_name, param_vals, evals_count=evals_count,
             )
             spectrum_data.matrixelem_table.update(new_spec.matrixelem_table)
-        # Verify if the shape of the matrix elements is correct
         elif all(
             spectrum_data.matrixelem_table[op].shape[1]
             != spectrum_data.matrixelem_table[op].shape[2]
             for op in noise_operators
         ):
             new_spec = self.get_matelements_vs_paramvals(
-                noise_operators, param_name, param_vals, evals_count=evals_count
+                noise_operators, param_name, param_vals, evals_count=evals_count,
             )
             for op in noise_operators:
                 spectrum_data.matrixelem_table[op] = new_spec.matrixelem_table[op]
 
-        param_vals = spectrum_data.param_vals
-
         dE_d_lambda = np.diagonal(
-            spectrum_data.matrixelem_table[noise_operators[0]], axis1=1, axis2=2
-        )
-        dEij_d_lambda = dE_d_lambda[:, :, np.newaxis] - dE_d_lambda[:, np.newaxis, :]
-        rate_1er = (
-            np.abs(dEij_d_lambda)
-            * A_noise
-            * np.sqrt(2 * np.abs(np.log(p["omega_ir"] * p["t_exp"])))
+            spectrum_data.matrixelem_table[noise_operators[0]], axis1=1, axis2=2,
         )
 
         if len(noise_operators) > 1:
             spectrum_data = self.get_d2E_d_param_vs_paramvals(
-                operators=noise_operators, spectrum_data=spectrum_data
+                operators=noise_operators, spectrum_data=spectrum_data,
             )
-            d2E_dX2 = spectrum_data.d2E_table[f"d2E_d_{deriv_param}2"]
-            d2Eij_d_lambda2 = d2E_dX2[:, :, np.newaxis] - d2E_dX2[:, np.newaxis, :]
-            rate_2nd = (
-                np.abs(d2Eij_d_lambda2)
-                * A_noise**2
-                * np.sqrt(
-                    2 * np.log(p["omega_uv"] / p["omega_ir"]) ** 2
-                    + 2 * np.log(p["omega_ir"] * p["t_exp"]) ** 2
-                )
-            )
-        elif len(noise_operators) == 1:
-            rate_2nd = 0
+            d2E_table = spectrum_data.d2E_table[f"d2E_d_{deriv_param}2"]
+        else:
+            d2E_table = None
 
-        rate = np.sqrt(rate_1er**2 + rate_2nd**2)
-        epsilon = 1e-12  # Pequeña constante para evitar divisiones por cero
-        rate = np.where(rate == 0, epsilon, rate)
-        rate *= 2 * np.pi * 1e9  # Convert to rad/s
-        tphi_table = 1 / rate
-
-        for idx in range(tphi_table.shape[0]):
-            np.fill_diagonal(tphi_table[idx], np.nan)
-
-        spectrum_data.tphi_table[noise_channel] = tphi_table
-
+        spectrum_data.tphi_table[noise_channel] = _noise.tphi_1_over_f_table(
+            dE_d_lambda_table=dE_d_lambda,
+            A_noise=A_noise,
+            d2E_d_lambda2_table=d2E_table,
+            omega_ir=p["omega_ir"],
+            omega_uv=p["omega_uv"],
+            t_exp=p["t_exp"],
+        )
         return spectrum_data
 
     def get_tphi_flux_vs_paramvals(
@@ -1641,22 +1113,16 @@ class QubitBase(ABC):
         """
 
         if spectrum_data is None:
-            # Validate parameters before calling get_matelements_vs_paramvals
-
             if param_name is None or param_vals is None:
                 raise ValueError("param_name and param_vals cannot be None")
-
             spectrum_data = self.get_matelements_vs_paramvals(
-                "displacement_operator", param_name, param_vals, evals_count=evals_count
+                "displacement_operator", param_name, param_vals, evals_count=evals_count,
             )
         elif "displacement_operator" not in spectrum_data.matrixelem_table:
-            # Validate spectrum_data parameters
-
             if spectrum_data.param_name is None or spectrum_data.param_vals is None:
                 raise ValueError(
                     "spectrum_data.param_name and spectrum_data.param_vals cannot be None"
                 )
-
             new_spec = self.get_matelements_vs_paramvals(
                 "displacement_operator",
                 spectrum_data.param_name,
@@ -1666,38 +1132,20 @@ class QubitBase(ABC):
             spectrum_data.matrixelem_table["displacement_operator"] = (
                 new_spec.matrixelem_table["displacement_operator"]
             )
-        phase_slip_frequency = (
-            4 * np.sqrt(2) / np.pi * fp / np.sqrt(z) * np.exp(-4 / np.pi / z)
+
+        El_values = (
+            np.asarray(param_vals, dtype=float) if param_name == "El"
+            else np.full(spectrum_data.energy_table.shape[0], getattr(self, "El", 1.0))
         )
 
-        displacement_operator = spectrum_data.matrixelem_table["displacement_operator"]
-        displacement_operator_diagonal = np.diagonal(
-            displacement_operator, axis1=1, axis2=2
+        spectrum_data.tphi_table["CQPS"] = _noise.tphi_cqps_table(
+            displacement_op_matelems_table=spectrum_data.matrixelem_table[
+                "displacement_operator"
+            ],
+            El_values=El_values,
+            fp=fp,
+            z=z,
         )
-
-        structure_factor = (
-            displacement_operator_diagonal[:, :, np.newaxis]
-            - displacement_operator_diagonal[:, np.newaxis, :]
-        )
-
-        if param_name == "El":
-            N_junctions = fp / 2 / np.pi / (param_vals * 1e9) / z
-        else:
-            N_junctions = fp / 2 / np.pi / (getattr(self, "El", 1.0) * 1e9) / z
-
-        rate = (
-            np.pi
-            * np.sqrt(N_junctions)
-            * phase_slip_frequency
-            * np.abs(structure_factor)
-        )
-        rate[rate == 0] = np.inf
-        tphi_table = 1 / rate
-
-        noise_channel = "CQPS"
-
-        spectrum_data.tphi_table[noise_channel] = tphi_table
-
         return spectrum_data
 
     def get_tphi_vs_paramvals(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name        = "HybridSuperQubits"
-version = "0.11.0"
+version = "0.12.0"
 description = "Package to simulate hybrid superconducting qubits"
 authors     = ["Joan Cáceres <contact@joancaceres.com>"]
 license     = "MIT"

--- a/tests/integration/test_noise_sweep_parity.py
+++ b/tests/integration/test_noise_sweep_parity.py
@@ -1,0 +1,177 @@
+"""Parity tests for Phase B sweep refactor.
+
+For each ``get_t1_*_vs_paramvals`` / ``get_tphi_*_vs_paramvals`` method:
+call it on a real Fluxonium and confirm the resulting t1/tphi table is
+identical (numerically, not just close) to what we get by:
+
+1. Building the spectrum + matrix elements via the existing helpers
+2. Calling the corresponding standalone function in ``HybridSuperQubits.noise``
+
+This guarantees the wrapper layer adds no physics — only orchestration.
+"""
+
+import numpy as np
+import pytest
+
+from HybridSuperQubits import noise
+
+
+@pytest.fixture
+def param_vals():
+    # Small flux sweep around the avoided crossing — gives non-trivial T1/Tphi.
+    return np.linspace(0.1, np.pi - 0.1, 4)
+
+
+# ---------------------------------------------------------------------------
+# T1 sweep parity
+# ---------------------------------------------------------------------------
+
+
+class TestT1SweepParity:
+    def test_capacitive(self, fluxonium, param_vals):
+        sd = fluxonium.get_t1_capacitive_vs_paramvals(
+            "phase", param_vals, evals_count=4,
+        )
+        Q_cap_fun = noise.default_Q_cap
+
+        def spectral_density(omega, T):
+            return noise.S_capacitive(omega, T, fluxonium.Ec, Q_cap_fun)
+
+        expected = noise.t1_table_from_spectral_density(
+            evals_table=sd.energy_table,
+            matelems_table=sd.matrixelem_table["n_operator"],
+            spectral_density=spectral_density,
+            T=0.015,
+        )
+        np.testing.assert_array_equal(sd.t1_table["capacitive"], expected)
+
+    def test_inductive(self, fluxonium, param_vals):
+        sd = fluxonium.get_t1_inductive_vs_paramvals(
+            "phase", param_vals, evals_count=4,
+        )
+        Q_ind_fun = noise.default_Q_ind_factory(0.015)
+
+        def spectral_density(omega, T):
+            return noise.S_inductive(omega, T, fluxonium.El, Q_ind_fun)
+
+        expected = noise.t1_table_from_spectral_density(
+            evals_table=sd.energy_table,
+            matelems_table=sd.matrixelem_table["phase_operator"],
+            spectral_density=spectral_density,
+            T=0.015,
+        )
+        np.testing.assert_array_equal(sd.t1_table["inductive"], expected)
+
+    def test_charge_impedance(self, fluxonium, param_vals):
+        sd = fluxonium.get_t1_charge_impedance_vs_paramvals(
+            "phase", param_vals, evals_count=4,
+        )
+
+        def spectral_density(omega, T):
+            return noise.S_charge_impedance(omega, T, 50.0)
+
+        expected = noise.t1_table_from_spectral_density(
+            evals_table=sd.energy_table,
+            matelems_table=sd.matrixelem_table["n_operator"],
+            spectral_density=spectral_density,
+            T=0.015,
+        )
+        np.testing.assert_array_equal(sd.t1_table["charge_impedance"], expected)
+
+    def test_flux_bias_line(self, fluxonium, param_vals):
+        sd = fluxonium.get_t1_flux_bias_line_vs_paramvals(
+            "phase", param_vals, evals_count=4,
+        )
+
+        def spectral_density(omega, T):
+            return noise.S_flux_bias_line(omega, T, 2500.0, 50.0)
+
+        expected = noise.t1_table_from_spectral_density(
+            evals_table=sd.energy_table,
+            matelems_table=sd.matrixelem_table["d_hamiltonian_d_phase"],
+            spectral_density=spectral_density,
+            T=0.015,
+        )
+        np.testing.assert_array_equal(sd.t1_table["flux_bias_line"], expected)
+
+    def test_one_over_f_flux(self, fluxonium, param_vals):
+        sd = fluxonium.get_t1_1_over_f_flux_vs_paramvals(
+            "phase", param_vals, evals_count=4,
+        )
+
+        def spectral_density(omega, T):
+            return noise.S_one_over_f_flux(omega, T, 1e-6)
+
+        expected = noise.t1_table_from_spectral_density(
+            evals_table=sd.energy_table,
+            matelems_table=sd.matrixelem_table["d_hamiltonian_d_phase"],
+            spectral_density=spectral_density,
+            T=0.015,
+        )
+        np.testing.assert_array_equal(sd.t1_table["flux_noise"], expected)
+
+
+# ---------------------------------------------------------------------------
+# Tphi sweep parity
+# ---------------------------------------------------------------------------
+
+
+class TestTphiSweepParity:
+    def test_flux_first_order(self, fluxonium, param_vals):
+        """Tphi 1/f flux without the 2nd-order operator."""
+        sd = fluxonium._get_tphi_1_over_f_vs_paramvals(
+            param_name="phase",
+            param_vals=param_vals,
+            A_noise=1e-6,
+            noise_channel="flux_first_order_only",
+            noise_operators=["d_hamiltonian_d_phase"],
+            evals_count=4,
+        )
+        dE = np.diagonal(
+            sd.matrixelem_table["d_hamiltonian_d_phase"], axis1=1, axis2=2,
+        )
+        expected = noise.tphi_1_over_f_table(
+            dE_d_lambda_table=dE,
+            A_noise=1e-6,
+            d2E_d_lambda2_table=None,
+        )
+        np.testing.assert_array_equal(
+            sd.tphi_table["flux_first_order_only"], expected,
+        )
+
+    def test_flux_with_second_order(self, fluxonium, param_vals):
+        """Tphi 1/f flux WITH 2nd-order operator — the full default path.
+
+        Must use ``evals_count=fluxonium.dimension`` because
+        ``get_d2E_d_param_vs_paramvals`` always works at full dimension
+        (it silently recomputes if given fewer evals).
+        """
+        sd = fluxonium.get_tphi_flux_vs_paramvals(
+            "phase", param_vals, A_noise=1e-6, evals_count=fluxonium.dimension,
+        )
+        dE = np.diagonal(
+            sd.matrixelem_table["d_hamiltonian_d_phase"], axis1=1, axis2=2,
+        )
+        d2E = sd.d2E_table["d2E_d_phase2"]
+        expected = noise.tphi_1_over_f_table(
+            dE_d_lambda_table=dE,
+            A_noise=1e-6,
+            d2E_d_lambda2_table=d2E,
+        )
+        np.testing.assert_array_equal(sd.tphi_table["flux_noise"], expected)
+
+    def test_cqps(self, fluxonium, param_vals):
+        sd = fluxonium.get_tphi_CQPS_vs_paramvals(
+            "phase", param_vals, evals_count=4,
+        )
+        El_values = np.full(len(param_vals), fluxonium.El)
+        expected = noise.tphi_cqps_table(
+            displacement_op_matelems_table=sd.matrixelem_table[
+                "displacement_operator"
+            ],
+            El_values=El_values,
+            fp=17e9,
+            z=0.05,
+        )
+        # CQPS uses np.inf in rate-zero entries; allow exact match including inf.
+        np.testing.assert_array_equal(sd.tphi_table["CQPS"], expected)

--- a/tests/unit/test_noise.py
+++ b/tests/unit/test_noise.py
@@ -118,10 +118,10 @@ def test_t1_generic_matches_capacitive(two_level_evals, two_level_matelems):
     """``t1_from_spectral_density`` should reproduce ``t1_capacitive`` when fed
     the matching closure."""
     Ec = 1.0
-    Q_cap = noise._default_Q_cap
+    Q_cap = noise.default_Q_cap
 
     def sd(omega, T):
-        return noise._S_capacitive(omega, T, Ec, Q_cap)
+        return noise.S_capacitive(omega, T, Ec, Q_cap)
 
     t1_generic = noise.t1_from_spectral_density(
         evals=two_level_evals, matrix_elements=two_level_matelems,


### PR DESCRIPTION
Phase B of the #17 functional refactor. Closes the rest of the noise extraction started in #18 and reconciles a real physics divergence between the single-shot and sweep code paths.

## Summary

- Extended [`HybridSuperQubits.noise`](https://github.com/joanjcaceres/HybridSuperQubits/blob/refactor/noise-sweep-dispatchers/HybridSuperQubits/noise.py) with table-level pure functions:
  - `t1_table_from_spectral_density` — full T1 table from `(n_param, n_eval[, n_eval])` arrays
  - `tphi_1_over_f_table` — same for 1/f Tphi
  - `tphi_cqps_table` — same for CQPS
- Made the channel-specific spectral densities (`S_capacitive`, `S_inductive`, `S_flux_bias_line`, `S_charge_impedance`, `S_one_over_f_flux`, `S_critical_current`, `S_andreev`) public — a **single source of truth** shared by both the single-shot and sweep paths.
- Rewrote the 7 `get_t1_*_vs_paramvals` methods, 2 `get_tphi_*_vs_paramvals` methods, `get_tphi_CQPS_vs_paramvals`, and the internal `_get_t1_vs_paramvals` / `_get_tphi_1_over_f_vs_paramvals` dispatchers as thin wrappers (~10 lines each).
- New `_resolve_sweep_inputs` helper folds the 30-line param/spectrum boilerplate into one call.

## Breaking changes (called out in CHANGELOG)

1. **Physics reconciliation.** Single-shot `t1_capacitive`/`t1_inductive`/`t1_flux_bias_line` now match the sweep formulas exactly. Previously they differed by ~2x (capacitive) or used a different formula entirely (flux-bias-line). The sweep was the physically correct path. **User capacitive-T1 values from single-shot will change.**
2. **`total` keyword removed** from all `t1_*` single-shot functions and `get_t1_*_vs_paramvals` sweep methods. It was the switch that enabled the buggy `SD(+ω) + SD(-ω)` summing in single-shot; with the reconciliation there is no switch to flip. Passing `total=...` now raises `TypeError`.

## Test plan

- [x] `tests/integration/test_noise_sweep_parity.py` — 8 new parity tests pin **wrapper == direct standalone call** for every sweep variant (T1: capacitive, inductive, charge_impedance, flux_bias_line, 1_over_f_flux; Tphi: flux 1st-order, flux 2nd-order, CQPS). All use `np.testing.assert_array_equal` (exact, not allclose) to guarantee the wrapper layer adds zero physics.
- [x] `tests/unit/test_noise.py` updated for the consolidated public API (removed `_S_*` / `_default_Q_cap` private references). 14 unit tests still pass.
- [x] Phase A's `tests/integration/test_noise_parity.py` still passes — 7 wrapper-vs-standalone parities for Fluxonium and Ferbo single-shot remain green.
- [x] Full suite: 109/113 pass. The 4 failures (`test_potential_includes_berry_contribution[*]`, `test_ferbo_*_standard_params`) are the same pre-existing Berry-related regressions on `main` from commit 0017d2b — verified unrelated by stashing this branch's changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)