### PR TITLE
[codex] Add Ferbo ladder operators

### DIFF
--- a/HybridSuperQubits/ferbo.py
+++ b/HybridSuperQubits/ferbo.py
@@ -31,6 +31,8 @@ class Ferbo(QubitBase):
 
     OPERATOR_LABELS = {
         "n_operator": r"\hat{n}",
+        "a_operator": r"\hat{a}",
+        "adag_operator": r"\hat{a}^\dagger",
         "phase_operator": r"\hat{\phi}",
         "d_hamiltonian_d_ng": r"\partial \hat{H} / \partial n_g",
         "d_hamiltonian_d_phase": r"\partial \hat{H} / \partial \phi_{{ext}}",
@@ -168,6 +170,28 @@ class Ferbo(QubitBase):
             * (creation(self.dimension // 2) - destroy(self.dimension // 2))
         )
         return np.kron(np.eye(2), single_mode_n_operator)
+
+    def a_operator(self) -> np.ndarray:
+        """
+        Returns the bosonic annihilation operator.
+
+        Returns
+        -------
+        np.ndarray
+            The annihilation operator acting on the oscillator subspace.
+        """
+        return np.kron(np.eye(2), destroy(self.dimension // 2))
+
+    def adag_operator(self) -> np.ndarray:
+        """
+        Returns the bosonic creation operator.
+
+        Returns
+        -------
+        np.ndarray
+            The creation operator acting on the oscillator subspace.
+        """
+        return np.kron(np.eye(2), creation(self.dimension // 2))
 
     def phase_operator(self) -> np.ndarray:
         """

--- a/tests/unit/test_ferbo.py
+++ b/tests/unit/test_ferbo.py
@@ -73,6 +73,26 @@ class TestFerboOperators:
         expected_shape = (ferbo.dimension, ferbo.dimension)
         assert n_op.shape == expected_shape
 
+    def test_a_operator_shape(self, ferbo: Ferbo):
+        """Test that a_operator returns correct shape."""
+        a_op = ferbo.a_operator()
+        expected_shape = (ferbo.dimension, ferbo.dimension)
+        assert a_op.shape == expected_shape
+
+    def test_adag_operator_shape(self, ferbo: Ferbo):
+        """Test that adag_operator returns correct shape."""
+        adag_op = ferbo.adag_operator()
+        expected_shape = (ferbo.dimension, ferbo.dimension)
+        assert adag_op.shape == expected_shape
+
+    def test_adag_operator_is_adjoint_of_a_operator(
+        self, ferbo: Ferbo, tolerance: float
+    ):
+        """Test that adag_operator is the adjoint of a_operator."""
+        assert np.allclose(
+            ferbo.adag_operator(), ferbo.a_operator().conj().T, atol=tolerance
+        )
+
     def test_phase_operator_shape(self, ferbo: Ferbo):
         """Test that phase_operator returns correct shape."""
         phase_op = ferbo.phase_operator()


### PR DESCRIPTION
## Summary
- add `a_operator()` and `adag_operator()` to `Ferbo`
- expose the new operators through `OPERATOR_LABELS`
- cover shape and adjoint behavior in Ferbo unit tests

## Notes
The ladder operators act on the oscillator subspace and are lifted to the full Ferbo Hilbert space as `kron(I_2, operator)`.

## Testing
- `PYTHONPYCACHEPREFIX=/tmp/hybridsuperqubits-pycache python3 -m py_compile HybridSuperQubits/ferbo.py tests/unit/test_ferbo.py`

Pytest was not run in this shell because the local Python environment did not include pytest or the numerical simulation dependencies.